### PR TITLE
Add MySQL db recreate script

### DIFF
--- a/commands/discourse/sendcode.js
+++ b/commands/discourse/sendcode.js
@@ -1,3 +1,5 @@
+var dateFormat = require("dateformat");
+
 module.exports = {
 	name: 'sendcode',
 	description: 'Sends the user a code based on their discourse email',
@@ -29,12 +31,13 @@ module.exports = {
             if(email === undefined) {
                 msg.reply("The account name you entered does not exist");
             }else{
-                const date = new Date(new Date().getTime() + 60 * 60 * 24 * 1000);
+                const expDate = new Date(new Date().getTime() + 60 * 60 * 24 * 1000);
+                const expDateFormatted = dateFormat(expDate, "yyyy-mm-dd HH:MM:ss");
 
-                console.log(date)
+                console.log(expDateFormatted)
                 
-                var sql = `INSERT INTO verifications (username, id, expiration) VALUES ('${clientUsername[0]}', '${uuid}', '${date}')`;
-                con.query(sql, function (err, result) {
+                var sql = `INSERT INTO verifications (username, verify_id, expiration) VALUES ('${clientUsername[0]}', '${uuid}', '${expDateFormatted}')`;
+                con.query(sql, function (err) {
                     if (err) {
                     console.log(err);
                     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,11 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "dateformat": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.5.1.tgz",
+      "integrity": "sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q=="
+    },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "db-recreate": "node utils/data/db.js"
   },
   "author": "StevenC",
   "license": "ISC",
   "dependencies": {
     "@sendgrid/mail": "^7.4.0",
+    "dateformat": "^4.5.1",
     "discord.js": "^12.4.1",
     "dotenv": "^8.2.0",
     "mysql": "^2.18.1",

--- a/utils/data/db.js
+++ b/utils/data/db.js
@@ -32,7 +32,7 @@ const sql = `
     action varchar(255),
     length_of_time varchar(255),
     reason varchar(255),
-    invalid boolean,
+    valid boolean,
     moderator varchar(255)
   );
   

--- a/utils/data/db.js
+++ b/utils/data/db.js
@@ -1,0 +1,70 @@
+require('dotenv').config();
+const mysql = require('mysql');
+const readline = require('readline').createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+const con = mysql.createConnection({
+  user: process.env.DB_USER,
+  host: process.env.DB_HOST,
+  database: process.env.DB_DATABASE,
+  password: process.env.DB_PASSWORD,
+  multipleStatements: true
+  });
+
+const sql = `
+  SET foreign_key_checks = 0;
+  DROP TABLE IF EXISTS verifications, infractions, mod_log;
+  SET foreign_key_checks = 1;
+
+  CREATE TABLE verifications(
+    id INT AUTO_INCREMENT PRIMARY Key,
+    username varchar(255),
+    verify_id varchar(255) NOT NULL,
+    expiration DATETIME
+  );
+  
+  CREATE TABLE infractions(
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    timestamp DATETIME,
+    user varchar(255) NOT NULL,
+    action varchar(255),
+    length_of_time varchar(255),
+    reason varchar(255),
+    invalid boolean,
+    moderator varchar(255)
+  );
+  
+  CREATE TABLE mod_log(
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    timestamp DATETIME,
+    moderator varchar(255) NOT NULL,
+    action varchar(255),
+    length_of_time varchar(255),
+    reason varchar(255)
+  );`;
+
+function recreateDB() {
+  con.query(sql, function(err) {
+    err ? console.log(err) : console.log('Database recreated successfully');
+  });
+  
+  con.end(function(err) {
+    err ? console.log(err) : console.log('Connection closed gracefully');
+  });
+}
+
+readline.question(
+  `Are you sure you want to recreate your database? You will lose all your data. y/N  `,
+  answer => {
+    const lowerAns = answer.toLowerCase();
+    if (lowerAns === 'y' || lowerAns === 'yes') {
+      recreateDB();
+      readline.close();
+    } else {
+      console.log('Exiting. Data will not be lost.');
+      readline.close();
+    }
+  }
+);


### PR DESCRIPTION
### What issue is this solving?
Closes #15 

You can wipe the MySQL database and re-create all tables from scratch.
To use this new script, run the following command:
```bash
$ npm run db-recreate 
```

### Changes
- Adds new script to drop and recreate all current tables in the db.
  - This is mostly for dev/testing purposes and getting new contributors
    up and running.
- Adds new script command and `dateformat` dependency in `package.json`
- Uses new MySQL datetime format in `sendcode.js`

This script is for MySQL, but we may change over to Mongo in the future.

Whichever database we choose, it may be wise to switch over to an ORM
for database interaction. For MySQL, we could use [Sequelize](https://sequelize.org/master/index.html), for Mongo
we could use [Mongoose](https://mongoosejs.com/).

---

### Additional Information
- Any new dependencies to install (`npm install`)? YES
- Any special requirements to test? YES
  - Install the new deps
  - You need to have `DB_USER`, `DB_HOST`, `DB_DATABASE` and `DB_PASSWORD` for a MySQL db in your `.env` file
  - Your DB User must have perms to drop and create tables 