### PR TITLE
Fix denying of permissions to users with the Muted role

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ client.on('guildCreate', guild => {
 })
 
 // Denies reacting and message sending permissions for users with Muted role.
-client.on('guildMemberUpdate', (newMember) => {
+client.on('guildMemberUpdate', (oldMember, newMember) => {
   const muted = newMember.guild.roles.cache.find(role => role.name === "Muted")
   newMember.guild.channels.cache.forEach(channel => {
     if (channel.type === "text" && newMember === channel.members.find(member => member.id === newMember.id)) {


### PR DESCRIPTION
Add the oldMember parameter to the guildMemberUpdate event listener. Fixes the problem where users weren't being denied message sending and role reacting privileges.