### PR TITLE
Record unmute and unmuting part of tempmute only in mod_log

### DIFF
--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -20,7 +20,7 @@ module.exports = {
         setTimeout(() => {
             unmuteUser(msg, toTempMute);
             auditLogUnmute(msg, toTempMute, lengthOfTime);
-            recordUnmuteInDB(toTempMute, con);  
+            recordUnmuteInDB(con);  
         }, ms(lengthOfTime));
     },
 };
@@ -133,21 +133,18 @@ function recordMuteInDB(message, toTempMute, lengthOfTime, reason, connection) {
     });
 }
 
-function recordUnmuteInDB(toTempMute, connection) {
+function recordUnmuteInDB(connection) {
     let now = new Date()
     let timestamp = dateFormat(now, "yyyy-mm-dd HH:MM:ss")
 
-    var sqlInfractions2 = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) 
-    VALUES ('${timestamp}', '${toTempMute.id}', 'cc!tempmute', NULL, 'tempmute expired', true, 'automatic')`;
-
     var sqlModLog2 = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) 
-    VALUES ('${timestamp}', 'automatic', 'cc!tempmute', NULL, 'tempmute expired')`;
+    VALUES ('${timestamp}', 'automatic', 'cc!unmute', NULL, 'tempmute expired')`;
 
-    connection.query(`${sqlInfractions2}; ${sqlModLog2}`, function (err, result) {
+    connection.query(`${sqlModLog2}`, function (err, result) {
         if (err) {
         console.log(err);
         } else {
-        console.log("1 record inserted into infractions, 1 record inserted into mod_log.");
+        console.log("1 record inserted into mod_log.");
         }
     });
 }

--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -20,7 +20,7 @@ module.exports = {
         setTimeout(() => {
             unmuteUser(msg, toTempMute);
             auditLogUnmute(msg, toTempMute, lengthOfTime);
-            recordUnmuteInDB(con);  
+            recordUnmuteInDB(toTempMute, con);  
         }, ms(lengthOfTime));
     },
 };
@@ -133,12 +133,12 @@ function recordMuteInDB(message, toTempMute, lengthOfTime, reason, connection) {
     });
 }
 
-function recordUnmuteInDB(connection) {
+function recordUnmuteInDB(toTempMute, connection) {
     let now = new Date()
     let timestamp = dateFormat(now, "yyyy-mm-dd HH:MM:ss")
 
     var sqlModLog2 = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) 
-    VALUES ('${timestamp}', 'automatic', 'cc!unmute', NULL, 'tempmute expired')`;
+    VALUES ('${timestamp}', 'automatic', 'cc!unmute ${toTempMute}', NULL, 'tempmute expired')`;
 
     connection.query(`${sqlModLog2}`, function (err, result) {
         if (err) {

--- a/commands/mute/unmute.js
+++ b/commands/mute/unmute.js
@@ -13,7 +13,7 @@ module.exports = {
 
         unmuteUser(msg, toUnmute);
         auditLog(msg, toUnmute);
-        recordInDB(msg, toUnmute, con);
+        recordInDB(msg, con);
     },
 };
 
@@ -67,21 +67,18 @@ function auditLog(message, toUnmute) {
     channel.send(unmuteEmbed);
 }
 
-function recordInDB(message, toUnmute, connection) {
+function recordInDB(message, connection) {
     let now = new Date();
     let timestamp = dateFormat(now, "yyyy-mm-dd HH:MM:ss");
-
-    var sqlInfractions = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) 
-    VALUES ('${timestamp}', '${toUnmute.id}', 'cc!unmute', NULL, NULL, true, '${message.author.id}')`;
 
     var sqlModLog = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason)
     VALUES ('${timestamp}', '${message.author.id}', '${message}', NULL, NULL)`;
 
-    connection.query(`${sqlInfractions}; ${sqlModLog}`, function (err, result) {
+    connection.query(`${sqlModLog}`, function (err, result) {
         if (err) {
         console.log(err);
         } else {
-        console.log("1 record inserted into infractions, 1 record inserted into mod_log.");
+        console.log("1 record inserted into mod_log.");
         }
     });
 }


### PR DESCRIPTION
cc!unmute is only recorded in mod_log now, not infractions. The muting part of cc!tempmute is still recorded in both infractions and mod_log, but the unmuting part is now only recorded in mod_log and not infractions.

This is done so that unmutes and the unmuting part of tempmute will not be shown in a user's infractions when the cc!infractions command is used. Closes #67.