### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information if applicable):**
+ - OS: [e.g. iOS, macOS, Win, Linux]
+ - Browser [e.g. chrome, safari]
+ - Discord Platform [Mobile, Desktop, Browser]
+ - Version [e.g. 22]
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,15 +10,15 @@ assignees: ''
 ## Describe the bug
 A clear and concise description of what the bug is.
 
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
 ## To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
-
-## Expected behavior
-A clear and concise description of what you expected to happen.
 
 ### Screenshots
 If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+
+---
+
+## Purpose
+What will this feature provide?
+
+### Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Proposed Solution
+If you have an idea on how to implement this feature, please share!
+
+## Acceptance Criteria
+Please list the requirements the implementation of this feature should meet.
+- [ ]
+
+## Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Adds automatic issue templates for bug reports and feature requests. Closes #53

I don't think the table at the top of these files will show when contributors choose a template.  Unless I'm mistaken, that info is there for GitHub's automation.  If it does end up showing, we can always change the templates to not include that table and instead give the automation the info through a YAML file.