### PR TITLE
Escape SQL query values

### DIFF
--- a/commands/mute/mute.js
+++ b/commands/mute/mute.js
@@ -89,13 +89,15 @@ function recordInDB(message, toMute, reason, connection) {
     let now = new Date();
     let timestamp = dateFormat(now, "yyyy-mm-dd HH:MM:ss");
 
-    var sqlInfractions = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) 
-    VALUES ('${timestamp}', '${toMute.id}', 'cc!mute', NULL, '${reason}', true, '${message.author.id}')`;
+    const sql = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) 
+    VALUES (?, ?, 'cc!mute', NULL, ?, true, ?);
+    INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) 
+    VALUES (?, ?, ?, NULL, ?);`;
 
-    var sqlModLog = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) 
-    VALUES ('${timestamp}', '${message.author.id}', '${message}', NULL, '${reason}')`;
+    const values = [timestamp, toMute.id, reason, message.author.id, timestamp, message.author.id, message.content, reason];
+    const escaped = connection.format(sql, values);
 
-    connection.query(`${sqlInfractions}; ${sqlModLog}`, function (err, result) {
+    connection.query(escaped, function (err, result) {
         if (err) {
         console.log(err);
         } else {

--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -118,13 +118,15 @@ function recordMuteInDB(message, toTempMute, lengthOfTime, reason, connection) {
     let now = new Date();
     let timestamp = dateFormat(now, "yyyy-mm-dd HH:MM:ss");
 
-    var sqlInfractions = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) 
-    VALUES ('${timestamp}', '${toTempMute.id}', 'cc!tempmute', '${lengthOfTime}', '${reason}', true, '${message.author.id}')`;
+    const sql = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) 
+    VALUES (?, ?, 'cc!tempmute', ?, ?, true, ?);
+    INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) 
+    VALUES (?, ?, ?, ?, ?);`;
 
-    var sqlModLog = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) 
-    VALUES ('${timestamp}', '${message.author.id}', '${message}', '${lengthOfTime}', '${reason}')`;
+    const values = [timestamp, toTempMute.id, lengthOfTime, reason, message.author.id, timestamp, message.author.id, message.content, lengthOfTime, reason];
+    const escaped = connection.format(sql, values);
 
-    connection.query(`${sqlInfractions}; ${sqlModLog}`, function (err, result) {
+    connection.query(escaped, function (err, result) {
         if (err) {
         console.log(err);
         } else {
@@ -137,10 +139,13 @@ function recordUnmuteInDB(toTempMute, connection) {
     let now = new Date()
     let timestamp = dateFormat(now, "yyyy-mm-dd HH:MM:ss")
 
-    var sqlModLog2 = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) 
-    VALUES ('${timestamp}', 'automatic', 'cc!unmute ${toTempMute}', NULL, 'tempmute expired')`;
+    const sql2 = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) 
+    VALUES (?, 'automatic', ?, NULL, 'tempmute expired')`;
 
-    connection.query(`${sqlModLog2}`, function (err, result) {
+    const values2 = [timestamp, `cc!unmute ${toTempMute}`];
+    const escaped2 = connection.format(sql2, values2);
+
+    connection.query(escaped2, function (err, result) {
         if (err) {
         console.log(err);
         } else {

--- a/commands/mute/unmute.js
+++ b/commands/mute/unmute.js
@@ -71,10 +71,13 @@ function recordInDB(message, connection) {
     let now = new Date();
     let timestamp = dateFormat(now, "yyyy-mm-dd HH:MM:ss");
 
-    var sqlModLog = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason)
-    VALUES ('${timestamp}', '${message.author.id}', '${message}', NULL, NULL)`;
+    const sql = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason)
+    VALUES (?, ?, ?, NULL, NULL);`;
 
-    connection.query(`${sqlModLog}`, function (err, result) {
+    const values = [timestamp, message.author.id, message.content];
+    const escaped = connection.format(sql, values);
+
+    connection.query(escaped, function (err, result) {
         if (err) {
         console.log(err);
         } else {


### PR DESCRIPTION
Closes #71.

### Description
Escape values used in SQL queries and eliminate the need to use `multipleStatements: true` as an attribute of the database connection. (I have not removed this attribute since the warn command is still dependent on it.) Data inserted into the database should remain in the same format as before this change.

## Any helpful knowledge/context for the reviewer?
This is a refactoring of the mute commands (which are already in use) to escape values in SQL queries to prevent SQLi attacks. To test, your bot must have admin permissions (adding the Admin role in the dev test server will do) to mute/unmute/temporarily mute users. Alt accounts already exist in the dev server which can be used to test this command.

- [x] Code has been tested and does not produce errors.
- [x] Code is readable and formatted.
- [x] There isn't any unnecessary commented-out code.
