### PR TITLE
Escape values in warn command queries

### DIFF
--- a/commands/utility/warn.js
+++ b/commands/utility/warn.js
@@ -71,10 +71,24 @@ function recordInDB(msg, con, offendingUser, warningReason) {
   const now = new Date();
   const timestamp = dateFormat(now, 'yyyy-mm-dd HH:MM:ss');
 
-  const sqlInfractions = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) VALUES ('${timestamp}', '${offendingUser.id}', 'cc!warn', 'NULL', '${warningReason}', true, '${msg.author.id}')`;
-  const sqlModLog = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) VALUES ('${timestamp}', '${msg.author.id}', '${msg}', 'NULL', '${warningReason}')`;
+  const sql = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator)
+    VALUES (?, ?, 'cc!warn', NULL, ?, true, ?);
+    INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason)
+    VALUES (?, ?, ?, NULL, ?);`;
 
-  con.query(`${sqlInfractions}; ${sqlModLog}`, function (err, result) {
+  const values = [
+    timestamp,
+    offendingUser.id,
+    warningReason,
+    msg.author.id,
+    timestamp,
+    msg.author.id,
+    msg.content,
+    warningReason,
+  ];
+  const escaped = con.format(sql, values);
+
+  con.query(escaped, function (err, result) {
     if (err) {
       console.log(err);
       // Include a warning in case something goes wrong writing to the db


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #87.

## Description
Escape values in SQL queries in `warn.js`.

## Any helpful knowledge/context for the reviewer?

- To test, you must have permission to use the `cc!warn` command. This allows you to warn a user and therefore write a record into the `infractions` and `mod_log` tables.

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
