### PR TITLE
Update help command

### DIFF
--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -46,7 +46,8 @@ function canTempMute(message, args) {
         role.name === 'Super User'
     )
   ) {
-    data.err = 'You must be a moderator or admin to use this command.';
+    data.err =
+      'You must be a super user, moderator, or admin to use this command.';
     return data;
   }
 

--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -40,7 +40,10 @@ function canTempMute(message, args) {
   // Checks if user can perform command and validates message content.
   if (
     !message.member.roles.cache.some(
-      (role) => role.name === 'Moderator' || role.name === 'Admin'
+      (role) =>
+        role.name === 'Moderator' ||
+        role.name === 'Admin' ||
+        role.name === 'Super User'
     )
   ) {
     data.err = 'You must be a moderator or admin to use this command.';

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -55,7 +55,9 @@ module.exports = {
 
         case 'cc!unban':
         case 'unban':
-          msg.channel.send('`cc!unban [userid]`\nUnbans a user. *Admin only.*');
+          msg.channel.send(
+            '`cc!unban [userid]`\nUnbans a user. *Admin only.*'
+          );
           break;
 
         case 'cc!tempban':

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -1,3 +1,5 @@
+const Discord = require('discord.js');
+
 module.exports = {
   name: 'help',
   description: 'Send help message',
@@ -7,59 +9,131 @@ module.exports = {
         case 'cc!createroles':
         case 'createroles':
           msg.channel.send(
-            'Pulls all badges from Codecademy Discuss and create a roll for each one. *Admin priviliges required'
+            '`cc!createroles`\nPulls all badges from Codecademy Discuss and creates a role for each one. *Admin only.*'
           );
           break;
 
         case 'cc!deleteroles':
         case 'deleteroles':
           msg.channel.send(
-            'Deletes all roles created from Codecademy Discuss. *Admin priviliges required'
+            '`cc!deleteroles`\nDeletes all the roles added from Codecademy Discuss. *Admin only.*'
           );
           break;
 
         case 'cc!sendcode':
         case 'sendcode':
           msg.channel.send(
-            'Sends a varification code to your Codecademy Discull email. *requires you to insert your user name after command: cc!sendcode [username]'
+            '`cc!sendcode [username]`\nSends a verification code to your Codecademy Discuss email. *Requires you to provide your Codecademy Discuss username.*'
           );
           break;
 
         case 'cc!verify':
         case 'verify':
           msg.channel.send(
-            'Verifies that the code entered is valid and gives you a role for every badge you have on Discourse. *requires you to enter your verification code after command: cc!verify [code]'
+            '`cc!verify [code]`\nVerifies that the code entered is valid and gives you a role for every badge you have on Discourse. *Requires you to enter your verification code.*'
           );
           break;
 
         case 'cc!ping':
         case 'ping':
-          msg.channel.send('Responds with Pong.');
+          msg.channel.send('`cc!ping`\nPong!');
           break;
 
         case 'cc!stats':
         case 'stats':
           msg.channel.send(
-            'Displays numbers of online members, offline members, and total members.'
+            '`cc!stats`\nDisplays basic server statistics (online members, offline members, total members).'
+          );
+          break;
+
+        case 'cc!ban':
+        case 'ban':
+          msg.channel.send(
+            '`cc!ban [user] [reason]`\nBans a user. *Admin only.*'
+          );
+          break;
+
+        case 'cc!unban':
+        case 'unban':
+          msg.channel.send('`cc!unban [userid]`\nUnbans a user. *Admin only.*');
+          break;
+
+        case 'cc!tempban':
+        case 'tempban':
+          msg.channel.send(
+            '`cc!tempban [user] [lengthoftime] [reason]`\nTemporarily bans a user for a set time period. *Moderator and above only.*'
+          );
+          break;
+
+        case 'cc!kick':
+        case 'kick':
+          msg.channel.send(
+            '`cc!kick [user] [reason]`\nKicks a user from the server. *Super User and above only.*'
+          );
+          break;
+
+        case 'cc!mute':
+        case 'mute':
+          msg.channel.send(
+            '`cc!mute [user] [reason]`\nMutes a user by assigning them a *Muted* role (denies message sending and reacting privileges). *Moderator and above only.*'
+          );
+          break;
+
+        case 'cc!unmute':
+        case 'unmute':
+          msg.channel.send(
+            '`cc!unmute [user]`\nUnmutes a user. *Super User and above only.*'
+          );
+          break;
+
+        case 'cc!tempmute':
+        case 'tempmute':
+          msg.channel.send(
+            '`cc!tempmute [user] [lengthoftime] [reason]`\nTemporarily mutes a user for a set time period. *Super User and above only.*'
+          );
+          break;
+
+        case 'cc!warn':
+        case 'warn':
+          msg.channel.send(
+            '`cc!warn [user] [reason]`\nWarns a user of an infraction and logs infraction in db. *Super User and above only.*'
+          );
+          break;
+
+        case 'cc!infractions':
+        case 'infractions':
+          msg.channel.send(
+            '`cc!infractions [user]`\nFinds user infraction record in db and returns it to channel. *Super User and above only.*'
           );
           break;
 
         default:
           msg.channel.send(
-            'That is not a command. For a full list type cc!help'
+            'That is not a command. For a full list type `cc!help`.'
           );
       }
     } else {
-      msg.channel.send(`**Commands**
-    cc!createroles* - Pulls all badges from Codecademy Discuss and creates a role for each one.
-    cc!deleteroles* - Deletes all the roles added from Codecademy Discuss.
-                        
-    cc!sendcode [username] - Sends a verification code to your Codecademy Discuss email.
-    cc!verify [code] - Verifies that the code entered is valid and gives you a role for every badge you have on Discourse.
-    cc!ping - Responds with "Pong.".
-    cc!stats - Displays number of online, offline, and total members.
-    cc!help - Displays this page.
-    *Admin Only`);
+      const commandsEmbed = new Discord.MessageEmbed()
+        .setTitle('Commands')
+        .setDescription(
+          'Use `cc!help [command]` to get more information about a particular command.'
+        )
+        .setColor('DARK_NAVY')
+        .addField(
+          'Admin Only',
+          'cc!createroles, cc!deleteroles, cc!ban, cc!unban'
+        )
+        .addField('Moderator & Above Only', 'cc!tempban, cc!mute')
+        .addField(
+          'Super User & Above Only',
+          'cc!unmute, cc!tempmute, cc!kick, cc!warn, cc!infractions'
+        )
+        .addField(
+          'Everyone',
+          'cc!sendcode, cc!verify, cc!stats, cc!ping, cc!help'
+        );
+
+      msg.channel.send(commandsEmbed);
     }
   },
 };


### PR DESCRIPTION
Closes #90.

## Description
Edited cc!help to include new commands since it was last updated. `cc!help` now sends a MessageEmbed of the commands (sectioned by role access) rather than all the commands and descriptions. This is because we now have too many commands to be able to effectively list them all. Using `cc!help [command]` will still provide the user with the description specific to that command.

Side note: I also updated cc!tempmute to allow SUs to use it (this was an oversight when I initially wrote the command).

- [x] Code has been tested and does not produce errors.
- [x] Code is readable and formatted.
- [x] There isn't any unnecessary commented-out code.
