### PR TITLE
Addnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,24 @@ Every great Discord server needs a great bot. So we coded up our own. It does a 
 
 ## Current Commands
 
-|      Command        |         Arguments       |    Permission       |                      Description                                                                     |
-|:--------------------|:------------------------|:--------------------|:-----------------------------------------------------------------------------------------------------|
-| `cc!createroles`    | N/A                     | Admin               | Pulls all badges from Codecademy Discuss and creates a role for each one.                            |
-| `cc!deleteroles`    | N/A                     | Admin               | Deletes all the roles added from Codecademy Discuss.                                                 |
-| `cc!ban`            | [user] [reason]         | Admin               | Bans a user.                                                                                         |
-| `cc!unban`          | [userId]                | Admin               | Unbans a user.                                                                                       |
-| `cc!tempban`        | [user] [lengthoftime] [reason] | Admin, Mods  | Temporarily bans a user for a set time period.                                           |
-| `cc!mute`           | [user] [reason]         | Admin, Mods         | Mutes a user by assigning them a _Muted_ role (denies message sending and reacting privileges).      |
-| `cc!tempmute`       | [user] [lengthoftime] [reason] | Admin, Mods, SU | Temporarily mutes a user for a set time period.                                                   |
-| `cc!kick`           | [user] [reason]         | Admin, Mods, SU     | Kicks a user from the server.                                                                        |
-| `cc!warn`           | [user] [reason]         | Admin, Mods, SU     | Warns a user of an infraction and logs infraction in db.                                             | 
-| `cc!infractions`    | [user]                  | Admin, Mods, SU     | Finds user infraction record in db and returns it to channel.                                        |
-| `cc!unmute`         | [user]                  | Admin, Mods, SU     | Unmute a user.                                                                                       |
-| `cc!sendcode`       | [username]              | Everyone            | Sends a verification code to your Codecademy Discuss email.                                          |
-| `cc!verify`         | [code]                  | Everyone            | Verifies that the code entered is valid and gives you a role for every badge you have on Discourse.  |
-| `cc!stats`          | N/A                     | Everyone            | Displays basic server statistics (online members, offline members, total members).                   |
-| `cc!ping`           | N/A                     | Everyone            | Pong!                                                                                                |
-| `cc!help`           | {command}               | Everyone            | Show informations about a given commands or list all commands.                                       |
+| Command          | Arguments                      | Permission      | Description                                                                                         |
+| :--------------- | :----------------------------- | :-------------- | :-------------------------------------------------------------------------------------------------- |
+| `cc!createroles` | N/A                            | Admin           | Pulls all badges from Codecademy Discuss and creates a role for each one.                           |
+| `cc!deleteroles` | N/A                            | Admin           | Deletes all the roles added from Codecademy Discuss.                                                |
+| `cc!ban`         | [user] [reason]                | Admin           | Bans a user.                                                                                        |
+| `cc!unban`       | [userId]                       | Admin           | Unbans a user.                                                                                      |
+| `cc!tempban`     | [user] [lengthoftime] [reason] | Admin, Mods     | Temporarily bans a user for a set time period.                                                      |
+| `cc!mute`        | [user] [reason]                | Admin, Mods     | Mutes a user by assigning them a _Muted_ role (denies message sending and reacting privileges).     |
+| `cc!tempmute`    | [user] [lengthoftime] [reason] | Admin, Mods, SU | Temporarily mutes a user for a set time period.                                                     |
+| `cc!kick`        | [user] [reason]                | Admin, Mods, SU | Kicks a user from the server.                                                                       |
+| `cc!warn`        | [user] [reason]                | Admin, Mods, SU | Warns a user of an infraction and logs infraction in db.                                            |
+| `cc!infractions` | [user]                         | Admin, Mods, SU | Finds user infraction record in db and returns it to channel.                                       |
+| `cc!unmute`      | [user]                         | Admin, Mods, SU | Unmute a user.                                                                                      |
+| `cc!sendcode`    | [username]                     | Everyone        | Sends a verification code to your Codecademy Discuss email.                                         |
+| `cc!verify`      | [code]                         | Everyone        | Verifies that the code entered is valid and gives you a role for every badge you have on Discourse. |
+| `cc!stats`       | N/A                            | Everyone        | Displays basic server statistics (online members, offline members, total members).                  |
+| `cc!ping`        | N/A                            | Everyone        | Pong!                                                                                               |
+| `cc!help`        | {command}                      | Everyone        | Show informations about a given commands or list all commands.                                      |
 
 ## Other Functionality
 

--- a/app.js
+++ b/app.js
@@ -157,6 +157,10 @@ const commandParser = (msg) => {
     case 'tempmute':
       client.commands.get('tempmute').execute(msg, args, con);
       break;
+    
+    case 'addnote':
+      client.commands.get('addnote').execute(msg, con, args);
+      break;
 
     default:
       msg.reply('That is not a command. Try cc!help for information.');

--- a/app.js
+++ b/app.js
@@ -157,7 +157,7 @@ const commandParser = (msg) => {
     case 'tempmute':
       client.commands.get('tempmute').execute(msg, args, con);
       break;
-    
+
     case 'addnote':
       client.commands.get('addnote').execute(msg, con, args);
       break;

--- a/commands/moderation/addnote.js
+++ b/commands/moderation/addnote.js
@@ -45,7 +45,7 @@ function postEmbed(msg,targetUser,note){
       `${targetUser.user.username}#${targetUser.user.discriminator}`,
       `https://cdn.discordapp.com/avatars/${targetUser.user.id}/${targetUser.user.avatar}.png`
     )
-    .setTitle(`New note:`)
+    .setTitle(`New note`)
     .setColor(embedFlair[Math.floor(Math.random() * embedFlair.length)])
     .addField(`Note:`, `${note}`)
     .setTimestamp()

--- a/commands/moderation/addnote.js
+++ b/commands/moderation/addnote.js
@@ -20,16 +20,16 @@ module.exports = {
         if (!note) return msg.reply(`You forgot to write the note.`);
 
         // Feedback back to the command caller
-        postEmbed(msg,targetUser,note);
+        postEmbed(msg, targetUser, note);
 
         // write it to the db
-        addNoteToDB(msg,con,targetUser, note);
+        addNoteToDB(msg, con, targetUser, note);
       }
     }
   },
 };
 
-function postEmbed(msg,targetUser,note){
+function postEmbed(msg, targetUser, note) {
   const embedFlair = [
     '#f8f272',
     '#f98948',
@@ -51,7 +51,7 @@ function postEmbed(msg,targetUser,note){
     .setTimestamp()
     .setFooter(`${msg.guild.name}`);
 
-    msg.channel.send(embed);
+  msg.channel.send(embed);
 }
 
 function addNoteToDB(msg, con, targetUser, note) {
@@ -59,31 +59,21 @@ function addNoteToDB(msg, con, targetUser, note) {
   const timestamp = dateFormat(now, 'yyyy-mm-dd HH:MM:ss');
 
   const sql = `INSERT INTO user_notes (timestamp, user, moderator, note)
-    VALUES (?, ?, ?, ?);`
+    VALUES (?, ?, ?, ?);`;
 
-  const values = [
-    timestamp,
-    targetUser.id,
-    msg.author.id,
-    note,
-  ];
+  const values = [timestamp, targetUser.id, msg.author.id, note];
   const escaped = con.format(sql, values);
 
   con.query(escaped, function (err, result) {
     if (err) {
       console.log(err);
       // Include a warning in case something goes wrong writing to the db
-      msg.channel.send(
-        `Writing to the db failed!`
-      );
+      msg.channel.send(`Writing to the db failed!`);
     } else {
-      console.log(
-        `1 note added to table: user_notes`
-      );
+      console.log(`1 note added to table: user_notes`);
     }
   });
 }
-
 
 function canWriteNotes(msg) {
   if (
@@ -134,7 +124,9 @@ function notHighRoller(msg, targetUser) {
         role.name === 'Admin'
     )
   ) {
-    msg.reply(`You cannot write a note about a super user, moderator or admin.`);
+    msg.reply(
+      `You cannot write a note about a super user, moderator or admin.`
+    );
     return false;
   } else {
     return true;

--- a/commands/moderation/addnote.js
+++ b/commands/moderation/addnote.js
@@ -1,0 +1,151 @@
+const Discord = require('discord.js');
+const dateFormat = require('dateformat');
+
+module.exports = {
+  name: 'addnote',
+  description: 'write a user note and store in the db',
+  execute(msg, con, args) {
+    // Make sure only SU, Mods and Admin can run the command
+    const targetUser =
+      msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
+
+    if (canWriteNotes(msg)) {
+      if (
+        hasUserTarget(msg, targetUser) &&
+        notSelf(msg, targetUser) &&
+        notHighRoller(msg, targetUser)
+      ) {
+        // grab the note
+        const note = args.slice(1).join(' ');
+        if (!note) return msg.reply(`You forgot to write the note.`);
+
+        // Feedback back to the command caller
+        postEmbed(msg,targetUser,note);
+
+        // write it to the db
+        addNoteToDB(msg,con,targetUser, note);
+      }
+    }
+  },
+};
+
+function postEmbed(msg,targetUser,note){
+  const embedFlair = [
+    '#f8f272',
+    '#f98948',
+    '#a23e48',
+    '#6096ba',
+    '#86a873',
+    '#d3b99f',
+    '#6e6a6f',
+  ];
+
+  const embed = new Discord.MessageEmbed()
+    .setAuthor(
+      `${targetUser.user.username}#${targetUser.user.discriminator}`,
+      `https://cdn.discordapp.com/avatars/${targetUser.user.id}/${targetUser.user.avatar}.png`
+    )
+    .setTitle(`New note:`)
+    .setColor(embedFlair[Math.floor(Math.random() * embedFlair.length)])
+    .addField(`Note:`, `${note}`)
+    .setTimestamp()
+    .setFooter(`${msg.guild.name}`);
+
+    msg.channel.send(embed);
+}
+
+function addNoteToDB(msg, con, targetUser, note) {
+  const now = new Date();
+  const timestamp = dateFormat(now, 'yyyy-mm-dd HH:MM:ss');
+
+  const sql = `INSERT INTO user_notes (timestamp, user, moderator, note)
+    VALUES (?, ?, ?, ?);`
+
+  const values = [
+    timestamp,
+    targetUser.id,
+    msg.author.id,
+    note,
+  ];
+  const escaped = con.format(sql, values);
+
+  con.query(escaped, function (err, result) {
+    if (err) {
+      console.log(err);
+      // Include a warning in case something goes wrong writing to the db
+      msg.channel.send(
+        `Writing to the db failed!`
+      );
+    } else {
+      console.log(
+        `1 note added to table: user_notes`
+      );
+    }
+  });
+}
+
+
+function canWriteNotes(msg) {
+  if (
+    !msg.member.roles.cache.some(
+      (role) =>
+        role.name === 'Super User' ||
+        role.name === 'Moderator' ||
+        role.name === 'Admin'
+    )
+  ) {
+    msg.reply(
+      'You must be a Super User, Moderator or Admin to use this command.'
+    );
+    return false;
+  } else {
+    return true;
+  }
+}
+
+function hasUserTarget(msg, targetUser) {
+  // Asortment of answers to make the bot more fun
+  const failAttemptReply = [
+    `Notice how you didn't select a user? You need to mention a user.`,
+    `I was expecting a user, and you didn't provide one`,
+    `oops... you forgot to mention the user in your note`,
+    `If you don't include a user, we won't know who the note was for!`,
+    `No biggie, but you forgot your target user`,
+    `Please provide the user you are making a note about`,
+    `No user, no note. Mention a user and then we can write the note, okie?`,
+  ];
+
+  if (targetUser) {
+    return true;
+  } else {
+    msg.reply(
+      failAttemptReply[Math.floor(Math.random() * failAttemptReply.length)]
+    );
+    return false;
+  }
+}
+
+function notHighRoller(msg, targetUser) {
+  if (
+    targetUser.roles.cache.some(
+      (role) =>
+        role.name === 'Super User' ||
+        role.name === 'Moderator' ||
+        role.name === 'Admin'
+    )
+  ) {
+    msg.reply(`You cannot write a note about a super user, moderator or admin.`);
+    return false;
+  } else {
+    return true;
+  }
+}
+
+function notSelf(msg, targetUser) {
+  if (targetUser.id == msg.author.id) {
+    msg.reply(`You can't write notes to yourself!`);
+    return false;
+  } else {
+    return true;
+  }
+}

--- a/commands/moderation/addnote.js
+++ b/commands/moderation/addnote.js
@@ -18,6 +18,7 @@ module.exports = {
         // grab the note
         const note = args.slice(1).join(' ');
         if (!note) return msg.reply(`You forgot to write the note.`);
+        if (note.length > 255) return msg.reply(`Too long! Notes can only be 255 characters or less.`);
 
         // Feedback back to the command caller
         postEmbed(msg, targetUser, note);

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -55,9 +55,7 @@ module.exports = {
 
         case 'cc!unban':
         case 'unban':
-          msg.channel.send(
-            '`cc!unban [userid]`\nUnbans a user. *Admin only.*'
-          );
+          msg.channel.send('`cc!unban [userid]`\nUnbans a user. *Admin only.*');
           break;
 
         case 'cc!tempban':


### PR DESCRIPTION
## What issue is this solving?

Solves 3/4 request in #41 

### Description
The new command `cc!addnote [user] [note]` takes a user mention or ID and stores `note` in the db.
It logs: `timestamp`, `user id`, `moderator id`, `note` to table `user_notes` in the db.

Command checks:
- User has privileges to create a note
- A target for the command is provided (a user)
- Target is not an Admin, Mod, SU
- Target is not self
- A note was provided

Command provides feedback to the command caller in the channel the command was called with an embed message that provided details on target user, note content and timestamp.

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No idea what this means
- Any new dependencies to install? No
- Any special requirements to test? Admin/Mod/SU
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
✅  Code has been tested and does not produce errors
✅ Code is readable and formatted
✅ There isn't any unnecessary commented-out code

# :warning: THIS PR WILL BREAK THE BOT IF MERGED WITHOUT ADDITIONAL WORK
 This command uses a new table called `user_notes`. We need to make that table available in production or this will most likely crash the piñata
