### PR TITLE
Add msg_counter and user_notes tables

### DIFF
--- a/utils/data/db.js
+++ b/utils/data/db.js
@@ -15,7 +15,7 @@ const con = mysql.createConnection({
 
 const sql = `
   SET foreign_key_checks = 0;
-  DROP TABLE IF EXISTS verifications, infractions, mod_log;
+  DROP TABLE IF EXISTS verifications, infractions, mod_log, msg_counter, user_notes;
   SET foreign_key_checks = 1;
 
   CREATE TABLE verifications(
@@ -43,6 +43,20 @@ const sql = `
     action varchar(255),
     length_of_time varchar(255),
     reason varchar(255)
+  );
+  
+  CREATE TABLE msg_counter(
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    timestamp DATETIME,
+    channel_name VARCHAR(255)
+  );
+  
+  CREATE TABLE user_notes(
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    timestamp DATETIME,
+    user varchar(255) NOT NULL,
+    moderator varchar(255) NOT NULL,
+    note varchar(255)
   );`;
 
 function recreateDB() {


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #83

I am also going to work on a script that allows for creating/recreating a single table and adding single columns to existing tables.  Hopefully then it will be easier for @Vic-ST to update the production db. 

### Description
Adds `msg_counter` and `user_notes` tables to the db-recreate script.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is recreating the database necessary? YES
- Any new dependencies to install? NO
- Any special requirements to test? Just run `npm run db-recreate` and check that the tables were made.

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
