### PR TITLE
Add cc!helpcenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Every great Discord server needs a great bot. So we coded up our own. It does a 
 | `cc!verify`      | [code]                         | Everyone       | Verifies that the code entered is valid and gives you a role for every badge you have on Discourse. |
 | `cc!stats`       | N/A                            | Everyone       | Displays basic server statistics (online members, offline members, total members).                  |
 | `cc!ping`        | N/A                            | Everyone       | Pong!                                                                                               |
+| `cc!helpcenter`  | {plaintext}                    | Everyone       | Provides links to Codecademy's Help Center (either embedded or plaintext).                          |
 | `cc!help`        | {command}                      | Everyone       | Shows information about a given command or lists all commands.                                      |
 
 ## Other Functionality

--- a/app.js
+++ b/app.js
@@ -72,6 +72,7 @@ client.on('guildMemberUpdate', (oldMember, newMember) => {
   });
 });
 
+// Upon channel creation, mutes all users with Muted role in the new channel.
 client.on('channelCreate', (channel) => {
   if (channel.guild != null) {
     const muted = channel.guild.roles.cache.find(
@@ -109,7 +110,7 @@ const commandParser = (msg) => {
       break;
 
     case 'stats':
-      client.commands.get('stats').execute(msg, Discord);
+      client.commands.get('stats').execute(msg);
       break;
 
     case 'verify':
@@ -160,6 +161,10 @@ const commandParser = (msg) => {
 
     case 'addnote':
       client.commands.get('addnote').execute(msg, con, args);
+      break;
+
+    case 'helpcenter':
+      client.commands.get('helpcenter').execute(msg, args);
       break;
 
     default:

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -114,6 +114,13 @@ module.exports = {
           );
           break;
 
+        case 'cc!helpcenter':
+        case 'helpcenter':
+          msg.channel.send(
+            "`cc!helpcenter {plaintext}`\nProvides links to Codecademy's Help Center (either embedded or plaintext)."
+          );
+          break;
+
         default:
           msg.channel.send(
             'That is not a command. For a full list type `cc!help`.'
@@ -137,7 +144,7 @@ module.exports = {
         )
         .addField(
           'Everyone',
-          'cc!sendcode, cc!verify, cc!stats, cc!ping, cc!help'
+          'cc!sendcode, cc!verify, cc!stats, cc!ping, cc!helpcenter, cc!help'
         );
 
       msg.channel.send(commandsEmbed);

--- a/commands/utility/helpcenter.js
+++ b/commands/utility/helpcenter.js
@@ -1,0 +1,33 @@
+const Discord = require('discord.js');
+
+module.exports = {
+  name: 'helpcenter',
+  description: "Provides commonly used links to CC's Help Centre",
+
+  execute(msg, args) {
+    if (args == 'plaintext') {
+      msg.channel.send(
+        '**Codecademy Help Center:** https://help.codecademy.com/hc/en-us\n' +
+          '**Submit A Request:** https://help.codecademy.com/hc/en-us/requests/new\n' +
+          'All billing-related queries should be directed to the Submit A Request form linked above.'
+      );
+    } else {
+      const embed = new Discord.MessageEmbed()
+        .setTitle('Codecademy Help Center Resources')
+        .setColor('DARK_NAVY')
+        .addField(
+          'Codecademy Help Center',
+          'https://help.codecademy.com/hc/en-us'
+        )
+        .addField(
+          'Submit A Request',
+          'https://help.codecademy.com/hc/en-us/requests/new'
+        )
+        .setFooter(
+          'All billing-related queries should be directed to the Submit A Request form linked above.'
+        );
+
+      msg.reply(embed);
+    }
+  },
+};

--- a/commands/utility/stats.js
+++ b/commands/utility/stats.js
@@ -1,7 +1,9 @@
+const Discord = require('discord.js');
+
 module.exports = {
   name: 'stats',
   description: 'Basic server stats',
-  async execute(msg, Discord) {
+  async execute(msg) {
     const Embed = new Discord.MessageEmbed();
     Embed.setTitle(`Server Stats`);
     const fetchedMembers = await msg.guild.members.fetch();


### PR DESCRIPTION
Closes #104.

## Description
- Add `cc!helpcenter`, which provides links to CC's Help Center and Submit A Request form.
- If `plaintext` is provided as an argument, the links will be sent as plain text rather than an embed. This allows the links to be copied and pasted on mobile.
- Updated README.md and cc!help to include this new command.
- _Minor unrelated change:_ imported `discord.js` directly into the `cc!stats` command rather than having it passed as an argument into `execute()` to be consistent with the other commands.

## Any helpful knowledge/context for the reviewer?
- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test? No

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors.
- [x] Code is readable and formatted.
- [x] There isn't any unnecessary commented-out code.