### PR TITLE
Enable all commands to take in user ID

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,11 +148,11 @@ const commandParser = (msg) => {
       break;
 
     case 'mute':
-      client.commands.get('mute').execute(msg, con);
+      client.commands.get('mute').execute(msg, args, con);
       break;
 
     case 'unmute':
-      client.commands.get('unmute').execute(msg, con);
+      client.commands.get('unmute').execute(msg, args, con);
       break;
 
     case 'tempmute':

--- a/commands/moderation/ban.js
+++ b/commands/moderation/ban.js
@@ -26,7 +26,7 @@ function validBan(msg) {
   };
 
   if (!msg.member.roles.cache.some((role) => role.name === 'Admin')) {
-    data.err = msg.reply('You must be an Admin to use this command.');
+    data.err = 'You must be an Admin to use this command.';
     return data;
   }
 

--- a/commands/moderation/ban.js
+++ b/commands/moderation/ban.js
@@ -6,7 +6,7 @@ module.exports = {
   description: 'Ban a user',
 
   execute(msg, con, args) {
-    const {status, err, toBan, reason} = validBan(msg);
+    const {status, err, toBan, reason} = validBan(msg, args);
     if (!status) {
       return msg.reply(err);
     }
@@ -17,7 +17,7 @@ module.exports = {
   },
 };
 
-function validBan(msg) {
+function validBan(msg, args) {
   const data = {
     status: false,
     err: null,
@@ -30,7 +30,9 @@ function validBan(msg) {
     return data;
   }
 
-  data.toBan = msg.mentions.members.first();
+  data.toBan =
+    msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
+  console.log(data.toBan);
   if (!data.toBan) {
     data.err = 'Please provide a user to ban.';
     return data;
@@ -46,7 +48,7 @@ function validBan(msg) {
     return data;
   }
 
-  data.reason = msg.content.substr(msg.content.indexOf('>') + 2);
+  data.reason = args.slice(1).join(' ');
   if (data.reason === '') {
     data.err = 'Please provide a reason for banning.';
     return data;

--- a/commands/moderation/ban.js
+++ b/commands/moderation/ban.js
@@ -32,7 +32,6 @@ function validBan(msg, args) {
 
   data.toBan =
     msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
-  console.log(data.toBan);
   if (!data.toBan) {
     data.err = 'Please provide a user to ban.';
     return data;

--- a/commands/moderation/kick.js
+++ b/commands/moderation/kick.js
@@ -6,7 +6,7 @@ module.exports = {
   description: 'Kick a user',
 
   execute(msg, con, args) {
-    const {status, err, toKick, reason} = validKick(msg);
+    const {status, err, toKick, reason} = validKick(msg, args);
     if (!status) {
       return msg.reply(err);
     }
@@ -17,7 +17,7 @@ module.exports = {
   },
 };
 
-function validKick(msg) {
+function validKick(msg, args) {
   const data = {
     status: false,
     err: null,
@@ -40,7 +40,8 @@ function validKick(msg) {
   }
 
   // Grabs the user and makes sure that one was provided
-  data.toKick = msg.mentions.members.first();
+  data.toKick =
+    msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
   if (!data.toKick) {
     data.err = 'Please provide a user to kick.';
     return data;
@@ -59,7 +60,7 @@ function validKick(msg) {
   }
 
   // Checks that a reason was included
-  data.reason = msg.content.substr(msg.content.indexOf('>') + 2);
+  data.reason = args.slice(1).join(' ');
   if (data.reason === '') {
     data.err = 'Please provide a reason for kicking.';
     return data;

--- a/commands/moderation/tempban.js
+++ b/commands/moderation/tempban.js
@@ -45,18 +45,17 @@ function validTempBan(msg, args) {
     return data;
   }
 
-  const userInformation = /(<@!?\d+>)\s(\d+[yhwdms])\s(.+)$/;
+  const userInformation = /((<@!?\d+>)|(\d{17,18}))\s(\d+[yhwdms])\s(.+)$/;
 
   if (!args.join(' ').match(userInformation)) {
     data.err = "The command you sent isn't in a valid format";
     return data;
   }
 
-  [, data.userID, data.timeLength, data.reason] = args
-    .join(' ')
-    .match(userInformation);
+  [data.userID, data.timeLength, data.reason] = args;
 
-  data.toTempBan = msg.mentions.members.first();
+  data.toTempBan =
+    msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
   if (!data.toTempBan) {
     data.err = 'Please provide a user to temporarily ban.';
     return data;

--- a/commands/moderation/tempban.js
+++ b/commands/moderation/tempban.js
@@ -45,7 +45,7 @@ function validTempBan(msg, args) {
     return data;
   }
 
-  const userInformation = /((<@!?\d+>)|(\d{17,18}))\s(\d+[yhwdms])\s(.+)$/;
+  const userInformation = /((<@!?)?\d{17,}>?)\s(\d+[yhwdms])\s(.+)$/;
 
   if (!args.join(' ').match(userInformation)) {
     data.err = "The command you sent isn't in a valid format";

--- a/commands/mute/mute.js
+++ b/commands/mute/mute.js
@@ -5,8 +5,8 @@ module.exports = {
   name: 'mute',
   description: 'Mute a user',
 
-  execute(msg, con) {
-    const {status, err, toMute, reason} = canMute(msg);
+  execute(msg, args, con) {
+    const {status, err, toMute, reason} = canMute(msg, args);
     if (!status) {
       return msg.reply(err);
     }
@@ -17,7 +17,7 @@ module.exports = {
   },
 };
 
-function canMute(message) {
+function canMute(message, args) {
   const data = {
     status: false,
     err: null,
@@ -35,7 +35,9 @@ function canMute(message) {
     return data;
   }
 
-  data.toMute = message.mentions.members.first();
+  data.toMute =
+    message.mentions.members.first() ||
+    message.guild.members.cache.get(args[0]);
   if (!data.toMute) {
     data.err = 'Please provide a user to mute.';
     return data;
@@ -57,7 +59,7 @@ function canMute(message) {
     return data;
   }
 
-  data.reason = message.content.substr(message.content.indexOf('>') + 2);
+  data.reason = args.slice(1).join(' ');
   if (data.reason === '') {
     data.err = 'Please provide a reason for muting.';
     return data;

--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -51,7 +51,7 @@ function canTempMute(message, args) {
     return data;
   }
 
-  const commandRegex = /((<@!?\d+>)|(\d{17,18}))\s(\d+[yhwdms])\s(.+)$/;
+  const commandRegex = /((<@!?)?\d{17,}>?)\s(\d+[yhwdms])\s(.+)$/;
   if (!args.join(' ').match(commandRegex)) {
     data.err = "The command you sent isn't in a valid format.";
     return data;

--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -51,16 +51,16 @@ function canTempMute(message, args) {
     return data;
   }
 
-  const commandRegex = /(<@!?\d+>)\s(\d+[yhwdms])\s(.+)$/;
+  const commandRegex = /((<@!?\d+>)|(\d{17,18}))\s(\d+[yhwdms])\s(.+)$/;
   if (!args.join(' ').match(commandRegex)) {
     data.err = "The command you sent isn't in a valid format.";
     return data;
   }
-  [, data.userID, data.lengthOfTime, data.reason] = args
-    .join(' ')
-    .match(commandRegex);
+  [data.userID, data.lengthOfTime, data.reason] = args;
 
-  data.toTempMute = message.mentions.members.first();
+  data.toTempMute =
+    message.mentions.members.first() ||
+    message.guild.members.cache.get(args[0]);
   if (!data.toTempMute) {
     data.err = 'Please provide a user to temporarily mute.';
     return data;
@@ -106,7 +106,6 @@ function muteUser(message, toTempMute, lengthOfTime, reason) {
 }
 
 function unmuteUser(message, toTempMute) {
-  toTempMute = message.mentions.members.first();
   toTempMute.roles.remove(
     message.guild.roles.cache.find((role) => role.name === 'Muted')
   );

--- a/commands/mute/unmute.js
+++ b/commands/mute/unmute.js
@@ -5,8 +5,8 @@ module.exports = {
   name: 'unmute',
   description: 'Unmute a user',
 
-  execute(msg, con) {
-    const {status, err, toUnmute} = canUnmute(msg);
+  execute(msg, args, con) {
+    const {status, err, toUnmute} = canUnmute(msg, args);
     if (!status) {
       return msg.reply(err);
     }
@@ -17,7 +17,7 @@ module.exports = {
   },
 };
 
-function canUnmute(message) {
+function canUnmute(message, args) {
   const data = {
     status: false,
     err: null,
@@ -37,7 +37,9 @@ function canUnmute(message) {
     return data;
   }
 
-  data.toUnmute = message.mentions.members.first();
+  data.toUnmute =
+    message.mentions.members.first() ||
+    message.guild.members.cache.get(args[0]);
   if (!data.toUnmute) {
     data.err = 'Please provide a user to unmute.';
     return data;

--- a/commands/utility/warn.js
+++ b/commands/utility/warn.js
@@ -6,7 +6,8 @@ module.exports = {
   description: 'warns a user of an infraction and logs infraction in db',
   execute(msg, con, args) {
     // Make sure only SU, Mods and Admin can run the command
-    const offendingUser = msg.mentions.members.first();
+    const offendingUser =
+      msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
     if (canWarn(msg)) {
       if (
         hasUserTarget(msg, offendingUser) &&


### PR DESCRIPTION
Closes #112.

## Description
- Most of our commands currently only accept a user mention that specifies what user the command should act on. These changes allow for both user mentions and user IDs to be used in all commands (with the exception of `cc!unban`, where only the user ID can be passed).
- Minor unrelated change: fixed a bug in the ban command that threw an error when no arguments were provided.

## Any helpful knowledge/context for the reviewer?
- Is a re-seeding of the database necessary? **No**
- Any new dependencies to install? **No**
- Any special requirements to test? **You must have permission to use all the commands (Admin role).**

### Please make sure you've attempted to meet the following coding standards.
- [x] Code has been tested and does not produce errors.
- [x] Code is readable and formatted.
- [x] There isn't any unnecessary commented-out code.
