### PR TITLE
Add bug reporting to plaintext

### DIFF
--- a/commands/utility/helpcenter.js
+++ b/commands/utility/helpcenter.js
@@ -9,6 +9,7 @@ module.exports = {
       msg.channel.send(
         '**Codecademy Help Center:** https://help.codecademy.com/hc/en-us\n' +
           '**Submit A Request:** https://help.codecademy.com/hc/en-us/requests/new\n' +
+          '**Bug Reporting:** To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.\n' +
           'All billing-related queries should be directed to the Submit A Request form linked above.'
       );
     } else {


### PR DESCRIPTION
Closes #130

## Description
Added the following to the cc!helpcenter command when plaintext is specified. This was already done in the embedded version in #121.
**Bug Reporting:** To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
