### PR TITLE
Remove notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Every great Discord server needs a great bot. So we coded up our own. It does a 
 | `cc!infractions`      | [user]                         | Admin, Mod, SU | Finds user infraction record in db and returns it to channel.                                       |
 | `cc!addnote`          | [user] [note]                  | Admin, Mod, SU | Adds a note to a user.                                                                              |
 | `cc!notes`            | [user]                         | Admin, Mod, SU | Displays all notes that have been added to a user.                                                  |
+| `cc!removenote`       | [noteid]                       | Admin, Mod, SU | Sets a single note as invalid.                                                                      |
 | `cc!sendcode`         | [username]                     | Everyone       | Sends a verification code to your Codecademy Discuss email.                                         |
 | `cc!verify`           | [code]                         | Everyone       | Verifies that the code entered is valid and gives you a role for every badge you have on Discourse. |
 | `cc!stats`            | N/A                            | Everyone       | Displays basic server statistics (online members, offline members, total members).                  |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Every great Discord server needs a great bot. So we coded up our own. It does a 
 | `cc!infractions`      | [user]                         | Admin, Mod, SU | Finds user infraction record in db and returns it to channel.                                       |
 | `cc!addnote`          | [user] [note]                  | Admin, Mod, SU | Adds a note to a user.                                                                              |
 | `cc!notes`            | [user]                         | Admin, Mod, SU | Displays all notes that have been added to a user.                                                  |
-| `cc!removenote`       | [noteid]                       | Admin, Mod, SU | Sets a single note as invalid.                                                                      |
+| `cc!removenote`       | [user] [noteid]                | Admin, Mod, SU | Sets a single note as invalid.                                                                      |
 | `cc!sendcode`         | [username]                     | Everyone       | Sends a verification code to your Codecademy Discuss email.                                         |
 | `cc!verify`           | [code]                         | Everyone       | Verifies that the code entered is valid and gives you a role for every badge you have on Discourse. |
 | `cc!stats`            | N/A                            | Everyone       | Displays basic server statistics (online members, offline members, total members).                  |

--- a/app.js
+++ b/app.js
@@ -179,6 +179,10 @@ const commandParser = (msg) => {
       client.commands.get('notes').execute(msg, con, args);
       break;
 
+    case 'removenote':
+      client.commands.get('removenote').execute(msg, args, con);
+      break;
+
     case 'helpcenter':
       client.commands.get('helpcenter').execute(msg, args);
       break;

--- a/commands/moderation/removenote.js
+++ b/commands/moderation/removenote.js
@@ -102,10 +102,8 @@ function noteSQL(msg, userNote, noteID, args, con) {
       console.log(err);
     } else {
       console.log('Note was set to invalid.');
-      if (result[0].affectedRows == 1) {
-        noteResponse(msg, userNote, noteID);
-        noteEmbed(msg, userNote, noteID);
-      }
+      noteResponse(msg, userNote, noteID);
+      noteEmbed(msg, userNote, noteID);
     }
   });
 }

--- a/commands/moderation/removenote.js
+++ b/commands/moderation/removenote.js
@@ -1,0 +1,136 @@
+const Discord = require('discord.js');
+const dateFormat = require('dateformat');
+
+module.exports = {
+  name: 'removenote',
+  description: 'Removes a specific note based on the note ID provided',
+
+  execute(msg, args, con) {
+    const {status, err, userNote, noteID} = validNote(msg, args);
+    if (!status) {
+      return msg.reply(err);
+    }
+
+    validatenoteID(msg, userNote, args, noteID, con);
+  },
+};
+
+function validNote(msg, args) {
+  const data = {
+    status: false,
+    err: null,
+    userNote: null,
+    noteID: null,
+  };
+
+  if (
+    !msg.member.roles.cache.some(
+      (role) =>
+        role.name === 'Admin' ||
+        role.name === 'Moderator' ||
+        role.name === 'Super User'
+    )
+  ) {
+    data.err =
+      'You must be an Admin, Moderator, or Super User to use this command.';
+    return data;
+  }
+
+  data.userNote =
+    msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
+  if (!data.userNote) {
+    data.err = 'Please provide a user to remove this note from.';
+    return data;
+  }
+
+  if (data.userNote === msg.member) {
+    data.err = 'You cannot remove a note from yourself.';
+    return data;
+  }
+
+  console.log(args);
+  data.noteID = args[1];
+  if (data.noteID === '') {
+    data.err = 'Please provide a note ID to remove.';
+    return data;
+  }
+
+  data.status = true;
+  return data;
+}
+
+function validatenoteID(msg, userNote, args, noteID, con) {
+  const sql = `SELECT user, valid FROM user_notes WHERE id = ?;`;
+
+  const values = [noteID];
+
+  const escaped = con.format(sql, values);
+
+  con.query(escaped, function (err, result) {
+    if (err) {
+      console.log(err);
+    } else {
+      if (result[0].user !== userNote.id) {
+        msg.reply('The specified note does not belong to the user.');
+      } else if (result[0] && result[0].valid == 0) {
+        msg.reply('This note has already been removed.');
+      } else if (result[0] && result[0].valid == 1) {
+        noteSQL(msg, userNote, noteID, args, con);
+      } else {
+        msg.reply('Please include a valid note ID.');
+      }
+    }
+  });
+}
+
+function noteSQL(msg, userNote, noteID, args, con) {
+  const now = new Date();
+  const date = dateFormat(now, 'yyyy-mm-dd HH:MM:ss');
+
+  const action = 'cc!removenote ' + args.join(' ');
+
+  // Inserts row into database
+  const sql = `UPDATE user_notes SET valid = ? WHERE id = ?;
+    INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) VALUES
+    (?, ?, ?, NULL, NULL);`;
+
+  const values = [false, noteID, date, msg.author.id, action];
+  const escaped = con.format(sql, values);
+
+  con.query(escaped, function (err, result) {
+    if (err) {
+      console.log(err);
+    } else {
+      console.log('Note was set to invalid.');
+      if (result[0].affectedRows == 1) {
+        noteResponse(msg, userNote, noteID);
+        noteEmbed(msg, userNote, noteID);
+      }
+    }
+  });
+}
+
+function noteEmbed(msg, userNote, noteID) {
+  // Sends Audit Log Embed
+  const channel = msg.guild.channels.cache.find(
+    (channel) => channel.name === 'audit-logs'
+  );
+
+  const userNoteEmbed = new Discord.MessageEmbed()
+    .setColor('#0099ff')
+    .setTitle(
+      `${msg.author.tag} removed an note from ${userNote.user.username}#${userNote.user.discriminator}`
+    )
+    .setDescription('Note #' + noteID)
+    .setThumbnail(
+      `https://cdn.discordapp.com/avatars/${userNote.user.id}/${userNote.user.avatar}.png`
+    )
+    .setTimestamp()
+    .setFooter(`${msg.guild.name}`);
+
+  channel.send(userNoteEmbed);
+}
+
+function noteResponse(msg, userNote, noteID) {
+  msg.reply(`Note #${noteID} was removed from ${userNote}.`);
+}

--- a/commands/moderation/removenote.js
+++ b/commands/moderation/removenote.js
@@ -8,10 +8,10 @@ module.exports = {
   execute(msg, args, con) {
     const {status, err, userNote, noteID} = validNote(msg, args);
     if (!status) {
-      return msg.reply(err);
+      msg.reply(err);
+    } else {
+      validatenoteID(msg, userNote, args, noteID, con);
     }
-
-    validatenoteID(msg, userNote, args, noteID, con);
   },
 };
 
@@ -50,7 +50,7 @@ function validNote(msg, args) {
 
   console.log(args);
   data.noteID = args[1];
-  if (data.noteID === '') {
+  if (!data.noteID) {
     data.err = 'Please provide a note ID to remove.';
     return data;
   }

--- a/commands/utility/clearinfractions.js
+++ b/commands/utility/clearinfractions.js
@@ -78,10 +78,8 @@ function clearInfractionSQL(msg, userInfraction, args, con) {
       console.log(err);
     } else {
       console.log('Infractions were removed from user');
-      if (result[0].affectedRows >= 1) {
-        clearInfractionResponse(msg, userInfraction);
-        clearInfractionEmbed(msg, userInfraction);
-      }
+      clearInfractionResponse(msg, userInfraction);
+      clearInfractionEmbed(msg, userInfraction);
     }
   });
 }

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -110,7 +110,7 @@ module.exports = {
         case 'cc!addnote':
         case 'addnote':
           msg.channel.send(
-            '`cc!addnote [user] [note]`\nAdds a note to a user.'
+            '`cc!addnote [user] [note]`\nAdds a note to a user. *Super User and above only.*'
           );
           break;
 
@@ -124,35 +124,35 @@ module.exports = {
         case 'cc!notes':
         case 'notes':
           msg.channel.send(
-            '`cc!notes [user]`\nDisplays all notes that have been added to a user.'
+            '`cc!notes [user]`\nDisplays all notes that have been added to a user. *Super User and above only.*'
           );
           break;
 
         case 'cc!removenote':
         case 'removenote':
           msg.channel.send(
-            '`cc!removenote [user] [noteid]`\nSets a single note as invalid.'
+            '`cc!removenote [user] [noteid]`\nSets a single note as invalid. *Super User and above only.*'
           );
           break;
 
         case 'cc!removeinfraction':
         case 'removeinfraction':
           msg.channel.send(
-            '`cc!removeinfraction [user] [infractionid]`\nSets a single infraction as invalid.'
+            '`cc!removeinfraction [user] [infractionid]`\nSets a single infraction as invalid. *Moderator and above only.*'
           );
           break;
 
         case 'cc!clearinfractions':
         case 'clearinfractions':
           msg.channel.send(
-            "`cc!clearinfractions [user]`\nSets all the specified user's infractions as invalid."
+            "`cc!clearinfractions [user]`\nSets all the specified user's infractions as invalid. *Admin only.*"
           );
           break;
 
         case 'cc!clearmessages':
         case 'clearmessages':
           msg.channel.send(
-            '`cc!clearmessages [numberofmessages]`\nClears the specified number of messages in the channel where the command is used.'
+            '`cc!clearmessages [numberofmessages]`\nClears the specified number of messages in the channel where the command is used. *Moderator and above only.*'
           );
           break;
 

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -131,7 +131,7 @@ module.exports = {
         case 'cc!removenote':
         case 'removenote':
           msg.channel.send(
-            '`cc!removenote [noteid]`\nSets a single note as invalid.'
+            '`cc!removenote [user] [noteid]`\nSets a single note as invalid.'
           );
           break;
 

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -128,6 +128,13 @@ module.exports = {
           );
           break;
 
+        case 'cc!removenote':
+        case 'removenote':
+          msg.channel.send(
+            '`cc!removenote [noteid]`\nSets a single note as invalid.'
+          );
+          break;
+
         case 'cc!removeinfraction':
         case 'removeinfraction':
           msg.channel.send(
@@ -171,7 +178,7 @@ module.exports = {
         )
         .addField(
           'Super User & Above Only',
-          'cc!unmute, cc!tempmute, cc!kick, cc!warn, cc!infractions, cc!addnote, cc!notes'
+          'cc!unmute, cc!tempmute, cc!kick, cc!warn, cc!infractions, cc!addnote, cc!removenote, cc!notes'
         )
         .addField(
           'Everyone',

--- a/commands/utility/removeinfraction.js
+++ b/commands/utility/removeinfraction.js
@@ -93,10 +93,8 @@ function infractionSQL(msg, userInfraction, infractionID, args, con) {
       console.log(err);
     } else {
       console.log('Infraction was set to invalid');
-      if (result[0].affectedRows == 1) {
-        infractionResponse(msg, userInfraction, infractionID);
-        infractionEmbed(msg, userInfraction, infractionID);
-      }
+      infractionResponse(msg, userInfraction, infractionID);
+      infractionEmbed(msg, userInfraction, infractionID);
     }
   });
 }

--- a/utils/data/tables.js
+++ b/utils/data/tables.js
@@ -51,6 +51,7 @@ const userNotes = {
     'user VARCHAR(255) NOT NULL',
     'moderator VARCHAR(255) NOT NULL',
     'note VARCHAR(255)',
+    'valid BOOLEAN DEFAULT true',
   ],
 };
 


### PR DESCRIPTION
Closes #128.

## Description
- `cc!removenote` sets a note to invalid.
- `cc!notes` now only displays notes which are valid.
- The database recreation function includes a new column in the `user_notes` table named `valid` to differentiate between active and "removed" notes.
- `cc!removenote` was added to README and cc!help.
- Minor unrelated change: added permissions required for several commands in cc!help.

## Any helpful knowledge/context for the reviewer?
Run the following command to create the new and necessary `valid` column in the `user_notes` table. Additionally, @Vic-ST, remember to do this on the droplet before merging to master.
```
npm run addcolumn table="user_notes" col="valid" type="BOOLEAN DEFAULT true"
```
- Is a re-seeding of the database necessary? **Users must have notes to be able to have them removed.**
- Any new dependencies to install? **No.**
- Any special requirements to test? **Command can only be used by SUs and above.**

### Please make sure you've attempted to meet the following coding standards.
- [x] Code has been tested and does not produce errors.
- [x] Code is readable and formatted.
- [x] There isn't any unnecessary commented-out code.