### PR TITLE
Allow multi-word reasons for commands using regex validation

### DIFF
--- a/commands/moderation/tempban.js
+++ b/commands/moderation/tempban.js
@@ -52,7 +52,9 @@ function validTempBan(msg, args) {
     return data;
   }
 
-  [data.userID, data.timeLength, data.reason] = args;
+  let reasonArray = null;
+  [data.userID, data.timeLength, ...reasonArray] = args;
+  data.reason = reasonArray.join(' ');
 
   data.toTempBan =
     msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);

--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -56,7 +56,10 @@ function canTempMute(message, args) {
     data.err = "The command you sent isn't in a valid format.";
     return data;
   }
-  [data.userID, data.lengthOfTime, data.reason] = args;
+
+  let reasonArray = null;
+  [data.userID, data.lengthOfTime, ...reasonArray] = args;
+  data.reason = reasonArray.join(' ');
 
   data.toTempMute =
     message.mentions.members.first() ||
@@ -92,7 +95,7 @@ function muteUser(message, toTempMute, lengthOfTime, reason) {
     message.guild.roles.cache.find((role) => role.name === 'Muted')
   );
   message.channel.send(
-    `${toTempMute} was muted by ${message.member}.\nReason: ${reason}`
+    `${toTempMute} was muted by ${message.member} for ${lengthOfTime}.\nReason: ${reason}`
   );
 
   // Sends user a DM notifying them of their muted status.
@@ -109,7 +112,6 @@ function unmuteUser(message, toTempMute) {
   toTempMute.roles.remove(
     message.guild.roles.cache.find((role) => role.name === 'Muted')
   );
-  message.channel.send(`${toTempMute} was unmuted.`);
   toTempMute.send("You've been unmuted.");
 }
 


### PR DESCRIPTION
Closes #134

## Description
Since a multi-word reason will result in each word being saved as a separate element in the `args` array, I've saved all of them into `reasonArray` and joined them together as a string before saving them in `data.reason`. Multi-word reasons should now work as expected for the `cc!tempmute` and `cc!tempban` commands (which are the ones that use regex for command format validation).

Also made a minor change to `cc!tempmute` so that it replies with the length of time the user was muted for in the channel that the command was used in, and also no longer sends a message in that same channel indicating that the user was unmuted (which is still sent in #audit-logs). This makes it consistent with how `cc!tempban` works.

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? **No.**
- Any new dependencies to install? **No.**
- Any special requirements to test? **Must have permission to use `cc!tempmute` and `cc!tempban`. You can test these changes on my alt account in the dev server if you don't have one of your own.**

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code