### PR TITLE
Only allow infractions belonging to the specified user to be removed

### DIFF
--- a/commands/utility/removeinfraction.js
+++ b/commands/utility/removeinfraction.js
@@ -64,7 +64,7 @@ function validateInfractionID(msg, userInfraction, args, infractionID, con) {
       console.log(err);
     } else {
       if (result[0].user !== userInfraction.id) {
-        msg.reply('Please include a valid infraction ID');
+        msg.reply('The specified infraction does not belong to that user.');
       } else if (result[0] && result[0].valid == 0) {
         msg.reply('Please include a valid infraction ID');
       } else if (result[0] && result[0].valid != 0) {

--- a/commands/utility/removeinfraction.js
+++ b/commands/utility/removeinfraction.js
@@ -53,7 +53,7 @@ function validInfraction(msg, args) {
 }
 
 function validateInfractionID(msg, userInfraction, args, infractionID, con) {
-  const sql = `SELECT id, valid FROM infractions WHERE id = ?;`;
+  const sql = `SELECT user, id, valid FROM infractions WHERE id = ?;`;
 
   const values = [infractionID];
 
@@ -63,10 +63,12 @@ function validateInfractionID(msg, userInfraction, args, infractionID, con) {
     if (err) {
       console.log(err);
     } else {
-      if (result[0] && result[0].valid != 0) {
-        infractionSQL(msg, userInfraction, infractionID, args, con);
+      if (result[0].user !== userInfraction.id) {
+        msg.reply('Please include a valid infraction ID');
       } else if (result[0] && result[0].valid == 0) {
         msg.reply('Please include a valid infraction ID');
+      } else if (result[0] && result[0].valid != 0) {
+        infractionSQL(msg, userInfraction, infractionID, args, con);
       } else {
         msg.reply('Please include a valid infraction ID');
       }


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #132 

### Description
<!-- Brief description of change -->
Changed the `validateInfractionID()` function to prevent the removal of infractions from unspecified users. Now, the infraction will be removed only if it belongs to the specified user. Nearly identical to what is already implemented in `cc!removenote`.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? Need one infraction to test.
- Any new dependencies to install? NO
- Any special requirements to test? Usual perms to be able to use `cc!removeinfraction`.
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
