### PR TITLE
Allow mods to ban+unban, remove archived from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,31 +8,27 @@ Every great Discord server needs a great bot. So we coded up our own. It does a 
 
 ## Current Commands
 
-| Command               | Arguments                      | Permission     | Description                                                                                         |
-| :-------------------- | :----------------------------- | :------------- | :-------------------------------------------------------------------------------------------------- |
-| `cc!createroles`      | N/A                            | Admin          | Pulls all badges from Codecademy Discuss and creates a role for each one.                           |
-| `cc!deleteroles`      | N/A                            | Admin          | Deletes all the roles added from Codecademy Discuss.                                                |
-| `cc!ban`              | [user] [reason]                | Admin          | Bans a user.                                                                                        |
-| `cc!unban`            | [userid]                       | Admin          | Unbans a user.                                                                                      |
-| `cc!clearinfractions` | [user]                         | Admin          | Sets all the specified user's infractions as invalid.                                               |
-| `cc!tempban`          | [user] [lengthoftime] [reason] | Admin, Mod     | Temporarily bans a user for a set time period.                                                      |
-| `cc!mute`             | [user] [reason]                | Admin, Mod     | Mutes a user by assigning them a _Muted_ role (denies message sending and reacting privileges).     |
-| `cc!removeinfraction` | [user] [infractionid]          | Admin, Mod     | Sets a single infraction as invalid.                                                                |
-| `cc!clearmessages`    | [numberofmessages]             | Admin, Mod     | Clears the specified number of messages in the channel where the command is used.                   |
-| `cc!unmute`           | [user]                         | Admin, Mod, SU | Unmutes a user.                                                                                     |
-| `cc!tempmute`         | [user] [lengthoftime] [reason] | Admin, Mod, SU | Temporarily mutes a user for a set time period.                                                     |
-| `cc!kick`             | [user] [reason]                | Admin, Mod, SU | Kicks a user from the server.                                                                       |
-| `cc!warn`             | [user] [reason]                | Admin, Mod, SU | Warns a user of an infraction and logs infraction in db.                                            |
-| `cc!infractions`      | [user]                         | Admin, Mod, SU | Finds user infraction record in db and returns it to channel.                                       |
-| `cc!addnote`          | [user] [note]                  | Admin, Mod, SU | Adds a note to a user.                                                                              |
-| `cc!notes`            | [user]                         | Admin, Mod, SU | Displays all notes that have been added to a user.                                                  |
-| `cc!removenote`       | [user] [noteid]                | Admin, Mod, SU | Sets a single note as invalid.                                                                      |
-| `cc!sendcode`         | [username]                     | Everyone       | Sends a verification code to your Codecademy Discuss email.                                         |
-| `cc!verify`           | [code]                         | Everyone       | Verifies that the code entered is valid and gives you a role for every badge you have on Discourse. |
-| `cc!stats`            | N/A                            | Everyone       | Displays basic server statistics (online members, offline members, total members).                  |
-| `cc!ping`             | N/A                            | Everyone       | Pong!                                                                                               |
-| `cc!helpcenter`       | {plaintext}                    | Everyone       | Provides links to Codecademy's Help Center (either embedded or plaintext).                          |
-| `cc!help`             | {command}                      | Everyone       | Shows information about a given command or lists all commands.                                      |
+| Command               | Arguments                      | Permission     | Description                                                                                     |
+| :-------------------- | :----------------------------- | :------------- | :---------------------------------------------------------------------------------------------- |
+| `cc!ban`              | [user] [reason]                | Admin          | Bans a user.                                                                                    |
+| `cc!unban`            | [userid]                       | Admin          | Unbans a user.                                                                                  |
+| `cc!clearinfractions` | [user]                         | Admin          | Sets all the specified user's infractions as invalid.                                           |
+| `cc!tempban`          | [user] [lengthoftime] [reason] | Admin, Mod     | Temporarily bans a user for a set time period.                                                  |
+| `cc!mute`             | [user] [reason]                | Admin, Mod     | Mutes a user by assigning them a _Muted_ role (denies message sending and reacting privileges). |
+| `cc!removeinfraction` | [user] [infractionid]          | Admin, Mod     | Sets a single infraction as invalid.                                                            |
+| `cc!clearmessages`    | [numberofmessages]             | Admin, Mod     | Clears the specified number of messages in the channel where the command is used.               |
+| `cc!unmute`           | [user]                         | Admin, Mod, SU | Unmutes a user.                                                                                 |
+| `cc!tempmute`         | [user] [lengthoftime] [reason] | Admin, Mod, SU | Temporarily mutes a user for a set time period.                                                 |
+| `cc!kick`             | [user] [reason]                | Admin, Mod, SU | Kicks a user from the server.                                                                   |
+| `cc!warn`             | [user] [reason]                | Admin, Mod, SU | Warns a user of an infraction and logs infraction in db.                                        |
+| `cc!infractions`      | [user]                         | Admin, Mod, SU | Finds user infraction record in db and returns it to channel.                                   |
+| `cc!addnote`          | [user] [note]                  | Admin, Mod, SU | Adds a note to a user.                                                                          |
+| `cc!notes`            | [user]                         | Admin, Mod, SU | Displays all notes that have been added to a user.                                              |
+| `cc!removenote`       | [user] [noteid]                | Admin, Mod, SU | Sets a single note as invalid.                                                                  |
+| `cc!stats`            | N/A                            | Everyone       | Displays basic server statistics (online members, offline members, total members).              |
+| `cc!ping`             | N/A                            | Everyone       | Pong!                                                                                           |
+| `cc!helpcenter`       | {plaintext}                    | Everyone       | Provides links to Codecademy's Help Center (either embedded or plaintext).                      |
+| `cc!help`             | {command}                      | Everyone       | Shows information about a given command or lists all commands.                                  |
 
 - Parameters in square brackets are mandatory, while those in curly braces are optional.
 - `[user]` can take either a user mention or user ID.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Every great Discord server needs a great bot. So we coded up our own. It does a 
 
 | Command               | Arguments                      | Permission     | Description                                                                                     |
 | :-------------------- | :----------------------------- | :------------- | :---------------------------------------------------------------------------------------------- |
-| `cc!ban`              | [user] [reason]                | Admin          | Bans a user.                                                                                    |
-| `cc!unban`            | [userid]                       | Admin          | Unbans a user.                                                                                  |
 | `cc!clearinfractions` | [user]                         | Admin          | Sets all the specified user's infractions as invalid.                                           |
+| `cc!ban`              | [user] [reason]                | Admin, Mod     | Bans a user.                                                                                    |
+| `cc!unban`            | [userid]                       | Admin, Mod     | Unbans a user.                                                                                  |
 | `cc!tempban`          | [user] [lengthoftime] [reason] | Admin, Mod     | Temporarily bans a user for a set time period.                                                  |
 | `cc!mute`             | [user] [reason]                | Admin, Mod     | Mutes a user by assigning them a _Muted_ role (denies message sending and reacting privileges). |
 | `cc!removeinfraction` | [user] [infractionid]          | Admin, Mod     | Sets a single infraction as invalid.                                                            |

--- a/commands/moderation/ban.js
+++ b/commands/moderation/ban.js
@@ -25,8 +25,12 @@ function validBan(msg, args) {
     reason: null,
   };
 
-  if (!msg.member.roles.cache.some((role) => role.name === 'Admin')) {
-    data.err = 'You must be an Admin to use this command.';
+  if (
+    !msg.member.roles.cache.some(
+      (role) => role.name === 'Admin' || role.name === 'Moderator'
+    )
+  ) {
+    data.err = 'You must be an Admin or Moderator to use this command.';
     return data;
   }
 

--- a/commands/moderation/unban.js
+++ b/commands/moderation/unban.js
@@ -28,8 +28,12 @@ async function validUnban(msg, args) {
     toUnban: null,
   };
 
-  if (!msg.member.roles.cache.some((role) => role.name === 'Admin')) {
-    data.err = 'You must be an Admin to use this command.';
+  if (
+    !msg.member.roles.cache.some(
+      (role) => role.name === 'Admin' || role.name === 'Moderator'
+    )
+  ) {
+    data.err = 'You must be an Admin or Moderator to use this command.';
     return data;
   }
 

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -140,10 +140,10 @@ module.exports = {
           'Use `cc!help [command]` to get more information about a particular command.'
         )
         .setColor('DARK_NAVY')
-        .addField('Admin Only', 'cc!ban, cc!unban, cc!clearinfractions')
+        .addField('Admin Only', 'cc!clearinfractions')
         .addField(
           'Moderator & Above Only',
-          'cc!tempban, cc!mute, cc!removeinfraction, cc!clearmessages'
+          'cc!ban, cc!unban, cc!tempban, cc!mute, cc!removeinfraction, cc!clearmessages'
         )
         .addField(
           'Super User & Above Only',

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -6,34 +6,6 @@ module.exports = {
   execute(msg, args, con) {
     if (args[0]) {
       switch (args[0]) {
-        case 'cc!createroles':
-        case 'createroles':
-          msg.channel.send(
-            '`cc!createroles`\nPulls all badges from Codecademy Discuss and creates a role for each one. *Admin only.*'
-          );
-          break;
-
-        case 'cc!deleteroles':
-        case 'deleteroles':
-          msg.channel.send(
-            '`cc!deleteroles`\nDeletes all the roles added from Codecademy Discuss. *Admin only.*'
-          );
-          break;
-
-        case 'cc!sendcode':
-        case 'sendcode':
-          msg.channel.send(
-            '`cc!sendcode [username]`\nSends a verification code to your Codecademy Discuss email. *Requires you to provide your Codecademy Discuss username.*'
-          );
-          break;
-
-        case 'cc!verify':
-        case 'verify':
-          msg.channel.send(
-            '`cc!verify [code]`\nVerifies that the code entered is valid and gives you a role for every badge you have on Discourse. *Requires you to enter your verification code.*'
-          );
-          break;
-
         case 'cc!ping':
         case 'ping':
           msg.channel.send('`cc!ping`\nPong!');
@@ -168,10 +140,7 @@ module.exports = {
           'Use `cc!help [command]` to get more information about a particular command.'
         )
         .setColor('DARK_NAVY')
-        .addField(
-          'Admin Only',
-          'cc!createroles, cc!deleteroles, cc!ban, cc!unban, cc!clearinfractions'
-        )
+        .addField('Admin Only', 'cc!ban, cc!unban, cc!clearinfractions')
         .addField(
           'Moderator & Above Only',
           'cc!tempban, cc!mute, cc!removeinfraction, cc!clearmessages'
@@ -180,10 +149,7 @@ module.exports = {
           'Super User & Above Only',
           'cc!unmute, cc!tempmute, cc!kick, cc!warn, cc!infractions, cc!addnote, cc!removenote, cc!notes'
         )
-        .addField(
-          'Everyone',
-          'cc!sendcode, cc!verify, cc!stats, cc!ping, cc!helpcenter, cc!help'
-        );
+        .addField('Everyone', 'cc!stats, cc!ping, cc!helpcenter, cc!help');
 
       msg.channel.send(commandsEmbed);
     }


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #155 

### Description
<!-- Brief description of change -->

- Allow mods to ban and unban users.
- Remove the four archived Discourse-related commands from cc!help and README.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? NO
- Any new dependencies to install? NO
- Any special requirements to test? Moderator role.
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
