### PR TITLE
Fix bot error when a command is given inside a DM channel

### DIFF
--- a/commands/moderation/addnote.js
+++ b/commands/moderation/addnote.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'addnote',
   description: 'write a user note and store in the db',
+  guildOnly: true,
   execute(msg, args, con) {
     // Make sure only SU, Mods and Admin can run the command
     const targetUser =

--- a/commands/moderation/ban.js
+++ b/commands/moderation/ban.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'ban',
   description: 'Ban a user',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, toBan, reason} = validBan(msg, args);

--- a/commands/moderation/clearmessages.js
+++ b/commands/moderation/clearmessages.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'clearmessages',
   description: 'Clears a certain number of messages',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, numberDeleted} = validClear(msg, args);

--- a/commands/moderation/filter.js
+++ b/commands/moderation/filter.js
@@ -41,6 +41,7 @@
 module.exports = {
   name: 'filter',
   description: 'filter a message',
+  guildOnly: true,
 
   execute(msg) {
     if (isHighRoller(msg)) {

--- a/commands/moderation/kick.js
+++ b/commands/moderation/kick.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'kick',
   description: 'Kick a user',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, toKick, reason} = validKick(msg, args);

--- a/commands/moderation/notes.js
+++ b/commands/moderation/notes.js
@@ -3,6 +3,7 @@ const Discord = require('discord.js');
 module.exports = {
   name: 'notes',
   description: 'finds user notes record in db and returns it to channel',
+  guildOnly: true,
   execute(msg, args, con) {
     // Make sure only SU, Mods and Admin can run the command
     const targetUser =

--- a/commands/moderation/removenote.js
+++ b/commands/moderation/removenote.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'removenote',
   description: 'Removes a specific note based on the note ID provided',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, userNote, noteID} = validNote(msg, args);

--- a/commands/moderation/tempban.js
+++ b/commands/moderation/tempban.js
@@ -5,6 +5,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'tempban',
   description: 'Temporarily ban a user',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, toTempBan, reason, timeLength} = validTempBan(

--- a/commands/moderation/unban.js
+++ b/commands/moderation/unban.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'unban',
   description: 'Unban a user',
+  guildOnly: true,
 
   async execute(msg, args, con) {
     const {status, err, toUnban} = await validUnban(msg, args);

--- a/commands/mute/mute.js
+++ b/commands/mute/mute.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'mute',
   description: 'Mute a user',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, toMute, reason} = canMute(msg, args);

--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -5,6 +5,7 @@ const ms = require('ms');
 module.exports = {
   name: 'tempmute',
   description: 'Temporarily mute a user',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, toTempMute, lengthOfTime, reason} = canTempMute(

--- a/commands/mute/unmute.js
+++ b/commands/mute/unmute.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'unmute',
   description: 'Unmute a user',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, toUnmute} = canUnmute(msg, args);

--- a/commands/utility/clearinfractions.js
+++ b/commands/utility/clearinfractions.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'clearinfractions',
   description: 'Removes all infractions from a user',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, userInfraction} = validInfraction(msg, args);

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -3,6 +3,7 @@ const Discord = require('discord.js');
 module.exports = {
   name: 'help',
   description: 'Send help message',
+  guildOnly: false,
   execute(msg, args, con) {
     if (args[0]) {
       switch (args[0]) {

--- a/commands/utility/helpcenter.js
+++ b/commands/utility/helpcenter.js
@@ -3,6 +3,7 @@ const Discord = require('discord.js');
 module.exports = {
   name: 'helpcenter',
   description: "Provides commonly used links to CC's Help Centre",
+  guildOnly: false,
 
   execute(msg, args, con) {
     if (args == 'plaintext') {

--- a/commands/utility/infractions.js
+++ b/commands/utility/infractions.js
@@ -3,6 +3,7 @@ const Discord = require('discord.js');
 module.exports = {
   name: 'infractions',
   description: 'finds user infraction record in db and returns it to channel',
+  guildOnly: true,
   execute(msg, args, con) {
     // Make sure only SU, Mods and Admin can run the command
     const targetUser =

--- a/commands/utility/ping.js
+++ b/commands/utility/ping.js
@@ -1,6 +1,7 @@
 module.exports = {
   name: 'ping',
   description: 'Ping!',
+  guildOnly: true,
   execute(message, args, con) {
     message.channel.send('Pong.');
   },

--- a/commands/utility/removeinfraction.js
+++ b/commands/utility/removeinfraction.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'removeinfraction',
   description: 'Removes a specific infraction based on the ID provided',
+  guildOnly: true,
 
   execute(msg, args, con) {
     const {status, err, userInfraction, infractionID} = validInfraction(

--- a/commands/utility/stats.js
+++ b/commands/utility/stats.js
@@ -3,6 +3,7 @@ const Discord = require('discord.js');
 module.exports = {
   name: 'stats',
   description: 'Basic server stats',
+  guildOnly: true,
   async execute(msg, args, con) {
     const Embed = new Discord.MessageEmbed();
     Embed.setTitle(`Server Stats`);

--- a/commands/utility/warn.js
+++ b/commands/utility/warn.js
@@ -4,6 +4,7 @@ const dateFormat = require('dateformat');
 module.exports = {
   name: 'warn',
   description: 'warns a user of an infraction and logs infraction in db',
+  guildOnly: true,
   execute(msg, args, con) {
     // Make sure only SU, Mods and Admin can run the command
     const offendingUser =

--- a/handlers/messageHandlers.js
+++ b/handlers/messageHandlers.js
@@ -21,6 +21,10 @@ const commandParser = async (client, con, msg) => {
 
   const command = client.commands.get(commandName);
 
+  if (command.guildOnly && msg.channel.type === 'dm') {
+    return msg.reply(`I can't execute that command inside DMs!`);
+  }
+
   try {
     await command.execute(msg, args, con);
   } catch (error) {


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #119 

### Description
<!-- Brief description of change -->
Added a `guildOnly` property to allow opting in and out of DM capability
for various commands.
<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?
The only two commands that I put as `guildOnly: false` are `cc!help` and `cc!helpcenter`.

- Is a re-seeding of the database necessary? NO
- Any new dependencies to install? NO
- Any special requirements to test? NO
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
