### PR TITLE
Update deploy workflow to use `npm ci`

### DIFF
--- a/.github/workflows/action_workflow.yml
+++ b/.github/workflows/action_workflow.yml
@@ -19,5 +19,5 @@ jobs:
           cd codecademy-discord-bot
           git pull origin master
           git status
-          npm install
+          npm ci
           pm2 restart 2


### PR DESCRIPTION
`npm ci` will do a fresh install of all node_modules and will not alter the local `package-lock.json` the way `npm install` sometimes will.  It will download and install packages based on what is in the remote `master` branch's `package-lock.json`.

(originally, I changed this directly on Master.  Should have done it on Dev first to begin with.  Will rebase this PR.)