### PR TITLE
Add permission handler

### DIFF
--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -4,6 +4,7 @@ module.exports = {
   name: 'help',
   description: 'Send help message',
   guildOnly: false,
+  staffOnly: false,
   execute(msg, args, con) {
     if (args[0]) {
       switch (args[0]) {

--- a/commands/utility/helpcenter.js
+++ b/commands/utility/helpcenter.js
@@ -4,7 +4,7 @@ module.exports = {
   name: 'helpcenter',
   description: "Provides commonly used links to CC's Help Centre",
   guildOnly: false,
-
+  staffOnly: false,
   execute(msg, args, con) {
     if (args == 'plaintext') {
       msg.channel.send(

--- a/commands/utility/ping.js
+++ b/commands/utility/ping.js
@@ -2,6 +2,7 @@ module.exports = {
   name: 'ping',
   description: 'Ping!',
   guildOnly: true,
+  staffOnly: false,
   execute(message, args, con) {
     message.channel.send('Pong.');
   },

--- a/commands/utility/stats.js
+++ b/commands/utility/stats.js
@@ -4,6 +4,7 @@ module.exports = {
   name: 'stats',
   description: 'Basic server stats',
   guildOnly: true,
+  staffOnly: false,
   async execute(msg, args, con) {
     const Embed = new Discord.MessageEmbed();
     Embed.setTitle(`Server Stats`);

--- a/handlers/messageHandlers.js
+++ b/handlers/messageHandlers.js
@@ -1,6 +1,7 @@
 const Discord = require('discord.js');
 const {getClient} = require('../config/client');
 const {getConnection} = require('../config/db');
+const {hasPermission} = require('../handlers/permissionHandlers');
 
 const con = getConnection();
 const client = getClient();
@@ -23,6 +24,10 @@ const commandParser = async (client, con, msg) => {
 
   if (command.guildOnly && msg.channel.type === 'dm') {
     return msg.reply(`I can't execute that command inside DMs!`);
+  }
+
+  if (command.staffOnly && !hasPermission(msg, command)) {
+    return msg.reply(`Sorry, you don't have permission to use that command!`);
   }
 
   try {

--- a/handlers/permissionHandlers.js
+++ b/handlers/permissionHandlers.js
@@ -15,7 +15,7 @@ function hasPermission(msg, command) {
     return false;
   }
 
-  if (!RoleEnum[highestRole] >= RoleEnum[command.minRole]) {
+  if (RoleEnum[highestRole] < RoleEnum[command.minRole]) {
     return false;
   }
 

--- a/handlers/permissionHandlers.js
+++ b/handlers/permissionHandlers.js
@@ -1,0 +1,28 @@
+const {has} = require('../helpers/has');
+
+const RoleEnum = {
+  Helper: 0, // Subject to change
+  'Super User': 1,
+  Moderator: 2,
+  Admin: 3,
+  'Super Admin': 4,
+};
+
+function hasPermission(msg, command) {
+  const highestRole = msg.member.roles.highest.name;
+
+  if (!has(RoleEnum, highestRole)) {
+    return false;
+  }
+
+  if (!RoleEnum[highestRole] >= RoleEnum[command.minRole]) {
+    return false;
+  }
+
+  return true;
+}
+
+module.exports = {
+  RoleEnum: RoleEnum,
+  hasPermission: hasPermission,
+};

--- a/helpers/has.js
+++ b/helpers/has.js
@@ -1,0 +1,29 @@
+// Borrowed from the Lodash library
+// https://github.com/lodash/lodash/blob/master/has.js
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * Checks if `key` is a direct property of `object`.
+ *
+ * @since 0.1.0
+ * @category Object
+ * @param {Object} object The object to query.
+ * @param {string} key The key to check.
+ * @return {boolean} Returns `true` if `key` exists, else `false`.
+ * @see hasIn, hasPath, hasPathIn
+ * @example
+ *
+ * const object = { 'a': { 'b': 2 } }
+ * const other = create({ 'a': create({ 'b': 2 }) })
+ *
+ * has(object, 'a')
+ * // => true
+ *
+ * has(other, 'a')
+ * // => false
+ */
+function has(object, key) {
+  return object != null && hasOwnProperty.call(object, key);
+}
+module.exports.has = has;


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #122 

### Description
<!-- Brief description of change -->
Add permissionHandler to DRY perms for commands.
 
This change helps us avoid duplicate permission handling logic in every
single command file by having a single handler that looks at attributes
of the command for guidance on minimum role needed.

This change requires each command to have the boolean `staffOnly`
attribute.  If `staffOnly` is `true`, then the command should also have
`minRole` attribute with the string name of the minimum role needed to
execute the command.
<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? NO
- Any new dependencies to install? NO
- Any special requirements to test? 
NO, because this PR only affects the commands that have no minimum role. PRs for Issues 123-125 will require special testing because they will replace the permission handling for all other commands.

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
