### PR TITLE
Migrate `clearinfractions` to new permission handler

### DIFF
--- a/commands/utility/clearinfractions.js
+++ b/commands/utility/clearinfractions.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'clearinfractions',
   description: 'Removes all infractions from a user',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Admin',
 
   execute(msg, args, con) {
     const {status, err, userInfraction} = validInfraction(msg, args);
@@ -22,12 +24,6 @@ function validInfraction(msg, args) {
     err: null,
     userInfraction: null,
   };
-
-  if (!msg.member.roles.cache.some((role) => role.name === 'Admin')) {
-    data.err = 'You must be an Admin to use this command.';
-    console.log(data);
-    return data;
-  }
 
   data.userInfraction =
     msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #123 

### Description
<!-- Brief description of change -->
Migrates the `clearinfractions` command to the new permission handler.  
Right now, this is the only command that is restricted to Admin-only.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? NO
- Any new dependencies to install? NO
- Any special requirements to test? YES
  - Because our highest role on the test server is "Better Then Admin", we can't test this out ourselves since the permission handler looks at the user's highest role.  I went ahead and made the "Super Admin", "Moderator" and "Super User" roles though, so you can test this by adding each of those to an alt account and using the `clearinfractions` command from that account. 

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
