### PR TITLE
Added time check

### DIFF
--- a/commands/utility/ping.js
+++ b/commands/utility/ping.js
@@ -6,9 +6,9 @@ module.exports = {
   async execute(message, args, con) {
     const response = await message.channel.send('Pinging!');
     response.edit(
-      `Ping! Took ${
+      `Pong! I took ${
         response.createdTimestamp - message.createdTimestamp
-      }ms to respond.`
+      }ms to respond 🏓`
     );
   },
 };

--- a/commands/utility/ping.js
+++ b/commands/utility/ping.js
@@ -3,7 +3,12 @@ module.exports = {
   description: 'Ping!',
   guildOnly: true,
   staffOnly: false,
-  execute(message, args, con) {
-    message.channel.send('Pong.');
+  async execute(message, args, con) {
+    const response = await message.channel.send('Pinging!');
+    response.edit(
+      `Ping! Took ${
+        response.createdTimestamp - message.createdTimestamp
+      }ms to respond.`
+    );
   },
 };


### PR DESCRIPTION
After the pong message is sent, comparison is done between the two messages timestamps to find out how long the response took

## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #184 

### Description
<!-- Brief description of change -->
When using the cc!ping command the bot will compare the timestamps of your message and its response. It then edits its answer with the time taken in milliseconds.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? Nada
- Any special requirements to test? Nope

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
