### PR TITLE
add webhook check

### DIFF
--- a/handlers/messageHandlers.js
+++ b/handlers/messageHandlers.js
@@ -9,7 +9,11 @@ const client = getClient();
 const messageHandler = async (msg) => {
   if (msg.content.substring(0, 3) === 'cc!') {
     await commandParser(client, con, msg);
-  } else if (msg.author.id != client.user.id && msg.guild !== null) {
+  } else if (
+    msg.author.id != client.user.id &&
+    msg.guild !== null &&
+    !msg.webhookID
+  ) {
     await client.commands.get('filter').execute(msg);
   }
 };


### PR DESCRIPTION
Before sending a message to the profanity filter it is checked for a webhook ID, and ignored if it has one.

## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #183 

### Description
<!-- Brief description of change -->
The message handler now checks the message for a webhook ID before calling the profanity filter. If there is an ID it ignores it.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? no
- Any new dependencies to install? no
- Any special requirements to test?:
    To test it you'll need to have a webhook sent in the development server. You can do this by starting your local bot and then forking the bots repository. The Github bot will then send a webhook on the dev server. 
    To test for regular messages you will need to use an account that does not have Super User, Moderator, or Admin roles.

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
