### PR TITLE
Update note permissions for Code Counselors

### DIFF
--- a/commands/moderation/addnote.js
+++ b/commands/moderation/addnote.js
@@ -104,6 +104,7 @@ function notHighRoller(msg, targetUser) {
   if (
     targetUser.roles.cache.some(
       (role) =>
+        role.name === 'Forums Super User' ||
         role.name === 'Code Counselor' ||
         role.name === 'Moderator' ||
         role.name === 'Admin'

--- a/commands/moderation/addnote.js
+++ b/commands/moderation/addnote.js
@@ -5,31 +5,29 @@ module.exports = {
   name: 'addnote',
   description: 'write a user note and store in the db',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Code Counselor',
   execute(msg, args, con) {
     // Make sure only SU, Mods and Admin can run the command
     const targetUser =
       msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
 
-    if (canWriteNotes(msg)) {
-      if (
-        hasUserTarget(msg, targetUser) &&
-        notSelf(msg, targetUser) &&
-        notHighRoller(msg, targetUser)
-      ) {
-        // grab the note
-        const note = args.slice(1).join(' ');
-        if (!note) return msg.reply(`You forgot to write the note.`);
-        if (note.length > 255)
-          return msg.reply(
-            `Too long! Notes can only be 255 characters or less.`
-          );
+    if (
+      hasUserTarget(msg, targetUser) &&
+      notSelf(msg, targetUser) &&
+      notHighRoller(msg, targetUser)
+    ) {
+      // grab the note
+      const note = args.slice(1).join(' ');
+      if (!note) return msg.reply(`You forgot to write the note.`);
+      if (note.length > 255)
+        return msg.reply(`Too long! Notes can only be 255 characters or less.`);
 
-        // Feedback back to the command caller
-        postEmbed(msg, targetUser, note);
+      // Feedback back to the command caller
+      postEmbed(msg, targetUser, note);
 
-        // write it to the db
-        addNoteToDB(msg, con, targetUser, note);
-      }
+      // write it to the db
+      addNoteToDB(msg, con, targetUser, note);
     }
   },
 };
@@ -80,24 +78,6 @@ function addNoteToDB(msg, con, targetUser, note) {
   });
 }
 
-function canWriteNotes(msg) {
-  if (
-    !msg.member.roles.cache.some(
-      (role) =>
-        role.name === 'Super User' ||
-        role.name === 'Moderator' ||
-        role.name === 'Admin'
-    )
-  ) {
-    msg.reply(
-      'You must be a Super User, Moderator or Admin to use this command.'
-    );
-    return false;
-  } else {
-    return true;
-  }
-}
-
 function hasUserTarget(msg, targetUser) {
   // Asortment of answers to make the bot more fun
   const failAttemptReply = [
@@ -124,13 +104,13 @@ function notHighRoller(msg, targetUser) {
   if (
     targetUser.roles.cache.some(
       (role) =>
-        role.name === 'Super User' ||
+        role.name === 'Code Counselor' ||
         role.name === 'Moderator' ||
         role.name === 'Admin'
     )
   ) {
     msg.reply(
-      `You cannot write a note about a super user, moderator or admin.`
+      `You cannot write a note about a Code Counselor, Moderator or Admin.`
     );
     return false;
   } else {

--- a/commands/moderation/notes.js
+++ b/commands/moderation/notes.js
@@ -4,17 +4,17 @@ module.exports = {
   name: 'notes',
   description: 'finds user notes record in db and returns it to channel',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Code Counselor',
   execute(msg, args, con) {
     // Make sure only SU, Mods and Admin can run the command
     const targetUser =
       msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
 
-    if (canCheckNotes(msg)) {
-      if (hasUserTarget(msg, targetUser)) {
-        // Find all notes records in database
-        // Because of async, call notesLog from notesInDB
-        notesInDB(msg, con, targetUser);
-      }
+    if (hasUserTarget(msg, targetUser)) {
+      // Find all notes records in database
+      // Because of async, call notesLog from notesInDB
+      notesInDB(msg, con, targetUser);
     }
   },
 };
@@ -120,24 +120,6 @@ function parseNotes(msg, notes) {
       );
   }
   return notesWithTimes;
-}
-
-function canCheckNotes(msg) {
-  if (
-    !msg.member.roles.cache.some(
-      (role) =>
-        role.name === 'Super User' ||
-        role.name === 'Moderator' ||
-        role.name === 'Admin'
-    )
-  ) {
-    msg.reply(
-      'You must be a Super User, Moderator or Admin to use this command.'
-    );
-    return false;
-  } else {
-    return true;
-  }
 }
 
 function hasUserTarget(msg, targetUser) {


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #125 

### Description
<!-- Brief description of change -->
Remove old permission check inside of the `addnote` and `notes` commands
and update them to the new permission handler.

Remove old SU permission and replace with Code Counselor perms.
<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? NO
- Any new dependencies to install? NO
- Any special requirements to test? YES
 

   - ⚠️ The best way to test this is to take away all your alt account's roles and then give it (one at a time) Forums Super User or Code Counselor roles.  Then have your alt try to add/view notes on your main account.
   - The Alt should not be able to do this when it has the FSU role (it will receive the message that it does not have the permissions)
   - The alt _should_ be able to add/view notes as a Code Counselor, but it can't add notes to a staff member, so it will say that.  That's okay. So long as it doesn't give the permission error about using the command then it's working.

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
