### PR TITLE
Migrate all Mod+ commands to use Permission Handler

### DIFF
--- a/commands/moderation/ban.js
+++ b/commands/moderation/ban.js
@@ -6,6 +6,8 @@ module.exports = {
   name: 'ban',
   description: 'Ban a user',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
   banIntro: "You've been banned for the following reason: ```",
   unbanRequest:
     ' ``` If you wish to challenge this ban, please submit a response in this Google Form: https://forms.gle/KxTMhPbi866r2FEz5',
@@ -37,15 +39,6 @@ function validBan(msg, args) {
     toBan: null,
     reason: null,
   };
-
-  if (
-    !msg.member.roles.cache.some(
-      (role) => role.name === 'Admin' || role.name === 'Moderator'
-    )
-  ) {
-    data.err = 'You must be an Admin or Moderator to use this command.';
-    return data;
-  }
 
   data.toBan =
     msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);

--- a/commands/moderation/clearmessages.js
+++ b/commands/moderation/clearmessages.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'clearmessages',
   description: 'Clears a certain number of messages',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
 
   execute(msg, args, con) {
     const {status, err, numberDeleted} = validClear(msg, args);
@@ -25,15 +27,6 @@ function validClear(msg, args) {
     numberDeleted: null,
     reason: null,
   };
-
-  if (
-    !msg.member.roles.cache.some(
-      (role) => role.name === 'Admin' || role.name === 'Moderator'
-    )
-  ) {
-    data.err = 'You must be an Admin or a Moderator to use this command.';
-    return data;
-  }
 
   data.numberDeleted = args[0];
   if (isNaN(args[0])) {

--- a/commands/moderation/kick.js
+++ b/commands/moderation/kick.js
@@ -6,6 +6,8 @@ module.exports = {
   name: 'kick',
   description: 'Kick a user',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
   kickIntro: "You've been kicked for the following reason: ```",
   kickOutro: ' ```',
 
@@ -36,20 +38,6 @@ function validKick(msg, args) {
     toKick: null,
     reason: null,
   };
-
-  if (
-    !msg.member.roles.cache.some(
-      (role) =>
-        role.name === 'Admin' ||
-        role.name === 'Moderator' ||
-        role.name === 'Super User'
-    )
-  ) {
-    data.err = msg.reply(
-      'You must be an Admin, Moderator, or Super User to use this command.'
-    );
-    return data;
-  }
 
   // Grabs the user and makes sure that one was provided
   data.toKick =

--- a/commands/moderation/removenote.js
+++ b/commands/moderation/removenote.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'removenote',
   description: 'Removes a specific note based on the note ID provided',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
 
   execute(msg, args, con) {
     const {status, err, userNote, noteID} = validNote(msg, args);
@@ -23,19 +25,6 @@ function validNote(msg, args) {
     userNote: null,
     noteID: null,
   };
-
-  if (
-    !msg.member.roles.cache.some(
-      (role) =>
-        role.name === 'Admin' ||
-        role.name === 'Moderator' ||
-        role.name === 'Super User'
-    )
-  ) {
-    data.err =
-      'You must be an Admin, Moderator, or Super User to use this command.';
-    return data;
-  }
 
   data.userNote =
     msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);

--- a/commands/moderation/tempban.js
+++ b/commands/moderation/tempban.js
@@ -7,6 +7,8 @@ module.exports = {
   name: 'tempban',
   description: 'Temporarily ban a user',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
   banIntro: "You've been banned for the following reason: ```",
   unbanRequest:
     ' ``` If you wish to challenge this ban, please submit a response in this Google Form: https://forms.gle/KxTMhPbi866r2FEz5',
@@ -49,15 +51,6 @@ function validTempBan(msg, args) {
     reason: null,
     timeLength: null,
   };
-
-  if (
-    !msg.member.roles.cache.some(
-      (role) => role.name === 'Admin' || role.name === 'Moderator'
-    )
-  ) {
-    data.err = 'You must be an Admin to use this command.';
-    return data;
-  }
 
   const userInformation = /((<@!?)?\d{17,}>?)\s(\d+[yhwdms])\s(.+)$/;
 

--- a/commands/moderation/unban.js
+++ b/commands/moderation/unban.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'unban',
   description: 'Unban a user',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
 
   async execute(msg, args, con) {
     const {status, err, toUnban} = await validUnban(msg, args);
@@ -28,15 +30,6 @@ async function validUnban(msg, args) {
     err: null,
     toUnban: null,
   };
-
-  if (
-    !msg.member.roles.cache.some(
-      (role) => role.name === 'Admin' || role.name === 'Moderator'
-    )
-  ) {
-    data.err = 'You must be an Admin or Moderator to use this command.';
-    return data;
-  }
 
   const userMention = msg.mentions.members.first();
   if (userMention) {

--- a/commands/mute/mute.js
+++ b/commands/mute/mute.js
@@ -6,6 +6,8 @@ module.exports = {
   name: 'mute',
   description: 'Mute a user',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
 
   execute(msg, args, con) {
     const {status, err, toMute, reason} = canMute(msg, args);
@@ -30,15 +32,6 @@ function canMute(message, args) {
   };
 
   // Checks if user can perform command and validates message content.
-  if (
-    !message.member.roles.cache.some(
-      (role) => role.name === 'Moderator' || role.name === 'Admin'
-    )
-  ) {
-    data.err = 'You must be a moderator or admin to use this command.';
-    return data;
-  }
-
   data.toMute =
     message.mentions.members.first() ||
     message.guild.members.cache.get(args[0]);

--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -7,6 +7,8 @@ module.exports = {
   name: 'tempmute',
   description: 'Temporarily mute a user',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
 
   execute(msg, args, con) {
     const {status, err, toTempMute, lengthOfTime, reason} = canTempMute(
@@ -42,18 +44,6 @@ function canTempMute(message, args) {
     reason: null,
   };
   // Checks if user can perform command and validates message content.
-  if (
-    !message.member.roles.cache.some(
-      (role) =>
-        role.name === 'Moderator' ||
-        role.name === 'Admin' ||
-        role.name === 'Super User'
-    )
-  ) {
-    data.err =
-      'You must be a super user, moderator, or admin to use this command.';
-    return data;
-  }
 
   const commandRegex = /((<@!?)?\d{17,}>?)\s(\d+[yhwdms])\s(.+)$/;
   if (!args.join(' ').match(commandRegex)) {

--- a/commands/mute/unmute.js
+++ b/commands/mute/unmute.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'unmute',
   description: 'Unmute a user',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
 
   execute(msg, args, con) {
     const {status, err, toUnmute} = canUnmute(msg, args);
@@ -25,19 +27,6 @@ function canUnmute(message, args) {
     toUnmute: null,
   };
   // Checks if user can perform command and validates message content.
-  if (
-    !message.member.roles.cache.some(
-      (role) =>
-        role.name === 'Moderator' ||
-        role.name === 'Admin' ||
-        role.name === 'Super User'
-    )
-  ) {
-    data.err =
-      'You must be a super user, moderator, or admin to use this command.';
-    return data;
-  }
-
   data.toUnmute =
     message.mentions.members.first() ||
     message.guild.members.cache.get(args[0]);

--- a/commands/utility/infractions.js
+++ b/commands/utility/infractions.js
@@ -4,18 +4,17 @@ module.exports = {
   name: 'infractions',
   description: 'finds user infraction record in db and returns it to channel',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
   execute(msg, args, con) {
     // Make sure only SU, Mods and Admin can run the command
     const targetUser =
       msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
 
-    if (targetUser) console.log(`targetUser is true`);
-    if (canCheckInfractions(msg)) {
-      if (hasUserTarget(msg, targetUser)) {
-        // Find all infraction records in database
-        // Because of async, call infractionLog from infractionsInDB
-        infractionsInDB(msg, con, targetUser);
-      }
+    if (hasUserTarget(msg, targetUser)) {
+      // Find all infraction records in database
+      // Because of async, call infractionLog from infractionsInDB
+      infractionsInDB(msg, con, targetUser);
     }
   },
 };
@@ -125,24 +124,6 @@ function parseInfractions(infractions) {
       );
   }
   return reasonsWithTimes;
-}
-
-function canCheckInfractions(msg) {
-  if (
-    !msg.member.roles.cache.some(
-      (role) =>
-        role.name === 'Super User' ||
-        role.name === 'Moderator' ||
-        role.name === 'Admin'
-    )
-  ) {
-    msg.reply(
-      'You must be a Super User, Moderator or Admin to use this command.'
-    );
-    return false;
-  } else {
-    return true;
-  }
 }
 
 function hasUserTarget(msg, targetUser) {

--- a/commands/utility/removeinfraction.js
+++ b/commands/utility/removeinfraction.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'removeinfraction',
   description: 'Removes a specific infraction based on the ID provided',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
 
   execute(msg, args, con) {
     const {status, err, userInfraction, infractionID} = validInfraction(
@@ -26,15 +28,6 @@ function validInfraction(msg, args) {
     userInfraction: null,
     infractionID: null,
   };
-
-  if (
-    !msg.member.roles.cache.some(
-      (role) => role.name === 'Admin' || role.name === 'Moderator'
-    )
-  ) {
-    data.err = 'You must be an Admin or Moderator to use this command.';
-    return data;
-  }
 
   data.userInfraction =
     msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);

--- a/commands/utility/warn.js
+++ b/commands/utility/warn.js
@@ -6,35 +6,36 @@ module.exports = {
   name: 'warn',
   description: 'warns a user of an infraction and logs infraction in db',
   guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
   execute(msg, args, con) {
     // Make sure only SU, Mods and Admin can run the command
     const offendingUser =
       msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
-    if (canWarn(msg)) {
-      if (
-        hasUserTarget(msg, offendingUser) &&
-        notSelf(msg, offendingUser) &&
-        notHighRoller(msg, offendingUser)
-      ) {
-        // Parse the reason for the warning
-        // if no reason provided, return so the bot doesn't go boom
-        const warningReason = args.slice(1).join(' ');
-        if (!warningReason) return msg.reply('You need to provide a reason');
 
-        if (!verifyReasonLength(msg.content, msg)) return;
+    if (
+      hasUserTarget(msg, offendingUser) &&
+      notSelf(msg, offendingUser) &&
+      notHighRoller(msg, offendingUser)
+    ) {
+      // Parse the reason for the warning
+      // if no reason provided, return so the bot doesn't go boom
+      const warningReason = args.slice(1).join(' ');
+      if (!warningReason) return msg.reply('You need to provide a reason');
 
-        // Create an embed, craft it, and DM the user
-        dmTheUser(msg, offendingUser, warningReason);
+      if (!verifyReasonLength(msg.content, msg)) return;
 
-        // Register call in the Audit-log channel
-        auditLog(msg, offendingUser, warningReason);
+      // Create an embed, craft it, and DM the user
+      dmTheUser(msg, offendingUser, warningReason);
 
-        // Give SU, Mod, Admin feedback on their call
-        msg.channel.send(`${msg.author} just warned ${offendingUser}`);
+      // Register call in the Audit-log channel
+      auditLog(msg, offendingUser, warningReason);
 
-        // Add the infraction to the database
-        recordInDB(msg, con, offendingUser, warningReason);
-      }
+      // Give SU, Mod, Admin feedback on their call
+      msg.channel.send(`${msg.author} just warned ${offendingUser}`);
+
+      // Add the infraction to the database
+      recordInDB(msg, con, offendingUser, warningReason);
     }
   },
 };
@@ -108,24 +109,6 @@ function recordInDB(msg, con, offendingUser, warningReason) {
   });
 }
 
-function canWarn(msg) {
-  if (
-    !msg.member.roles.cache.some(
-      (role) =>
-        role.name === 'Super User' ||
-        role.name === 'Moderator' ||
-        role.name === 'Admin'
-    )
-  ) {
-    msg.reply(
-      'You must be a Super User, Moderator or Admin to use this command.'
-    );
-    return false;
-  } else {
-    return true;
-  }
-}
-
 function hasUserTarget(msg, offendingUser) {
   // Asortment of answers to make the bot more fun
   const failAttemptReply = [
@@ -152,12 +135,12 @@ function notHighRoller(msg, offendingUser) {
   if (
     offendingUser.roles.cache.some(
       (role) =>
-        role.name === 'Super User' ||
+        role.name === 'Code Counselor' ||
         role.name === 'Moderator' ||
         role.name === 'Admin'
     )
   ) {
-    msg.reply('You cannot warn a super user, moderator or admin.');
+    msg.reply('You cannot warn a Code Counselor, Moderator or Admin.');
     return false;
   } else {
     return true;


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #124 

### Description
<!-- Brief description of change -->
Migrates the last of the commands to use the permission handler.
These are all Mod+ commands.
<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? NO
- Any new dependencies to install? NO
- Any special requirements to test? YES
 

   - ⚠️ The best way to test this is to take away all your alt account's roles and then give it (one at a time) Code Counselor or Moderator roles.  Then have your alt try to use all the commands here against your main account.
   - The Alt should not be able to do this when it has the Code Counselor role (it will receive the message that it does not have the permissions)
   - The alt _should_ be able to use these commands as a Moderator, but it can't add notes to a staff member, so it will say that.  That's okay. So long as it doesn't give the permission error about using the command then it's working.

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
