### PR TITLE
Update immune roles

### DIFF
--- a/commands/moderation/addnote.js
+++ b/commands/moderation/addnote.js
@@ -107,7 +107,8 @@ function notHighRoller(msg, targetUser) {
         role.name === 'Forums Super User' ||
         role.name === 'Code Counselor' ||
         role.name === 'Moderator' ||
-        role.name === 'Admin'
+        role.name === 'Admin' ||
+        role.name === 'Super Admin'
     )
   ) {
     msg.reply(

--- a/commands/moderation/filter.js
+++ b/commands/moderation/filter.js
@@ -61,9 +61,11 @@ const isHighRoller = (msg) => {
   if (
     !msg.member.roles.cache.some(
       (role) =>
-        role.name === 'Super User' ||
+        role.name === 'Forums Super User' ||
+        role.name === 'Code Counselor' ||
         role.name === 'Moderator' ||
-        role.name === 'Admin'
+        role.name === 'Admin' ||
+        role.name === 'Super Admin'
     )
   ) {
     return true;

--- a/commands/mute/mute.js
+++ b/commands/mute/mute.js
@@ -45,7 +45,11 @@ function canMute(message, args) {
   }
   if (
     data.toMute.roles.cache.some(
-      (role) => role.name === 'Moderator' || role.name === 'Admin'
+      (role) =>
+        role.name === 'Forums Super User' ||
+        role.name === 'Moderator' ||
+        role.name === 'Admin' ||
+        role.name === 'Super Admin'
     )
   ) {
     data.err = 'You cannot mute a moderator or admin.';

--- a/commands/mute/tempmute.js
+++ b/commands/mute/tempmute.js
@@ -68,7 +68,11 @@ function canTempMute(message, args) {
   }
   if (
     data.toTempMute.roles.cache.some(
-      (role) => role.name === 'Moderator' || role.name === 'Admin'
+      (role) =>
+        role.name === 'Forums Super User' ||
+        role.name === 'Moderator' ||
+        role.name === 'Admin' ||
+        role.name === 'Super Admin'
     )
   ) {
     data.err = 'You cannot temporarily mute a moderator or admin.';

--- a/commands/utility/warn.js
+++ b/commands/utility/warn.js
@@ -135,9 +135,11 @@ function notHighRoller(msg, offendingUser) {
   if (
     offendingUser.roles.cache.some(
       (role) =>
+        role.name === 'Forums Super User' ||
         role.name === 'Code Counselor' ||
         role.name === 'Moderator' ||
-        role.name === 'Admin'
+        role.name === 'Admin' ||
+        role.name === 'Super Admin'
     )
   ) {
     msg.reply('You cannot warn a Code Counselor, Moderator or Admin.');


### PR DESCRIPTION
### Description
Edited the list of immune roles for the applicable commands:
- `Super Admin` added to all.
- `Super User` changed to `Forums Super User` (the actual role on Discord still needs to be renamed).
- Code Counselors are now immune to the word filter.
- FSUs are now immune to warns, mutes, and tempmutes.

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test? Minimum role for the most restrictive command is Moderator.
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
