### PR TITLE
Add verbal to README and cc!help

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Every great Discord server needs a great bot, so we coded up our own. It does a 
 | `cc!tempmute`         | [user] [lengthoftime] [reason] | Admin, Mod                 | Temporarily mutes a user for a set time period.                                                 |
 | `cc!kick`             | [user] [reason]                | Admin, Mod                 | Kicks a user from the server.                                                                   |
 | `cc!warn`             | [user] [reason]                | Admin, Mod                 | Warns a user of an infraction and logs infraction in db.                                        |
+| `cc!verbal`           | [user] [reason]                | Admin, Mod                 | Sends a user a verbal through DMs and logs as a note in db.                                     |
 | `cc!infractions`      | [user]                         | Admin, Mod                 | Finds user infraction records in db and returns it to channel.                                  |
 | `cc!removenote`       | [user] [noteid]                | Admin, Mod                 | Sets a single note as invalid.                                                                  |
 | `cc!addnote`          | [user] [note]                  | Admin, Mod, Code Counselor | Adds a note to a user.                                                                          |

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -76,6 +76,13 @@ module.exports = {
           );
           break;
 
+        case 'cc!verbal':
+        case 'verbal':
+          msg.channel.send(
+            '`cc!verbal [user] [reason]`\nSends a user a verbal through DMs and logs as a note in db. *Moderator and above only.*'
+          );
+          break;
+
         case 'cc!infractions':
         case 'infractions':
           msg.channel.send(
@@ -147,7 +154,7 @@ module.exports = {
         .addField('Admin Only', 'cc!clearinfractions')
         .addField(
           'Moderator & Above Only',
-          'cc!ban, cc!unban, cc!tempban, cc!mute, cc!unmute, cc!tempmute, cc!kick, cc!warn, cc!infractions, cc!removeinfraction, cc!removenote, cc!clearmessages'
+          'cc!ban, cc!unban, cc!tempban, cc!mute, cc!unmute, cc!tempmute, cc!kick, cc!warn, cc!verbal, cc!infractions, cc!removeinfraction, cc!removenote, cc!clearmessages'
         )
         .addField('Code Counselor & Above Only', 'cc!addnote, cc!notes')
         .addField('Everyone', 'cc!stats, cc!ping, cc!helpcenter, cc!help');


### PR DESCRIPTION
Add documentation of `cc!verbal` (added in #202) to the README and cc!help command.