### PR TITLE
Updated `notes`, `addnote` and `verbal` commands to use hasTargetUser

### DIFF
--- a/commands/moderation/addnote.js
+++ b/commands/moderation/addnote.js
@@ -1,5 +1,6 @@
 const Discord = require('discord.js');
 const dateFormat = require('dateformat');
+const {hasTargetUser} = require('../../helpers/hasTargetUser');
 
 module.exports = {
   name: 'addnote',
@@ -13,7 +14,7 @@ module.exports = {
       msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
 
     if (
-      hasUserTarget(msg, targetUser) &&
+      hasTargetUser(msg, targetUser, 'add a note to') &&
       notSelf(msg, targetUser) &&
       notHighRoller(msg, targetUser)
     ) {
@@ -76,28 +77,6 @@ function addNoteToDB(msg, con, targetUser, note) {
       console.log(`1 note added to table: user_notes`);
     }
   });
-}
-
-function hasUserTarget(msg, targetUser) {
-  // Asortment of answers to make the bot more fun
-  const failAttemptReply = [
-    `Notice how you didn't select a user? You need to mention a user.`,
-    `I was expecting a user, and you didn't provide one`,
-    `oops... you forgot to mention the user in your note`,
-    `If you don't include a user, we won't know who the note was for!`,
-    `No biggie, but you forgot your target user`,
-    `Please provide the user you are making a note about`,
-    `No user, no note. Mention a user and then we can write the note, okie?`,
-  ];
-
-  if (targetUser) {
-    return true;
-  } else {
-    msg.reply(
-      failAttemptReply[Math.floor(Math.random() * failAttemptReply.length)]
-    );
-    return false;
-  }
 }
 
 function notHighRoller(msg, targetUser) {

--- a/commands/moderation/notes.js
+++ b/commands/moderation/notes.js
@@ -1,4 +1,5 @@
 const Discord = require('discord.js');
+const {hasTargetUser} = require('../../helpers/hasTargetUser');
 
 module.exports = {
   name: 'notes',
@@ -11,7 +12,7 @@ module.exports = {
     const targetUser =
       msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
 
-    if (hasUserTarget(msg, targetUser)) {
+    if (hasTargetUser(msg, targetUser, 'read notes from')) {
       // Find all notes records in database
       // Because of async, call notesLog from notesInDB
       notesInDB(msg, con, targetUser);
@@ -120,26 +121,4 @@ function parseNotes(msg, notes) {
       );
   }
   return notesWithTimes;
-}
-
-function hasUserTarget(msg, targetUser) {
-  // Asortment of answers to make the bot more fun
-  const failAttemptReply = [
-    'Ok there bud, whose notes are you trying to check again?',
-    'You definitely missed the target user there...',
-    'What? You want ALL the notes from everyone? You forgot the target user',
-    "Not judging, but you didn't set a user to read notes from...",
-    'You forgot the target user',
-    'Forgot the target user. Wanna try again?',
-    'Here I was thinking this command was easy enough. You forgot the target user',
-  ];
-
-  if (targetUser) {
-    return true;
-  } else {
-    msg.reply(
-      failAttemptReply[Math.floor(Math.random() * failAttemptReply.length)]
-    );
-    return false;
-  }
 }

--- a/commands/moderation/verbal.js
+++ b/commands/moderation/verbal.js
@@ -1,6 +1,7 @@
 const Discord = require('discord.js');
 const dateFormat = require('dateformat');
 const {verifyReasonLength} = require('../../helpers/stringHelpers');
+const {hasTargetUser} = require('../../helpers/hasTargetUser');
 
 module.exports = {
   name: 'verbal',
@@ -14,7 +15,7 @@ module.exports = {
       msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
 
     if (
-      hasUserTarget(msg, offendingUser) &&
+      hasTargetUser(msg, offendingUser, 'verbal') &&
       notSelf(msg, offendingUser) &&
       notHighRoller(msg, offendingUser)
     ) {
@@ -115,28 +116,6 @@ function recordInDB(msg, con, offendingUser, verbalReason) {
       );
     }
   });
-}
-
-function hasUserTarget(msg, offendingUser) {
-  // Asortment of answers to make the bot more fun
-  const failAttemptReply = [
-    'Ok there bud, who are you trying to verbal again?',
-    'You definitely missed the target user there...',
-    'shoot first ask later? You forgot the target user',
-    "Not judging, but you didn't set a user to verbal",
-    "Without a target user I can't verbal anyone but you",
-    'Forgot the target user. Wanna try again?',
-    'Please tell you *do* know who to verbal? You forgot the user',
-  ];
-
-  if (offendingUser) {
-    return true;
-  } else {
-    msg.reply(
-      failAttemptReply[Math.floor(Math.random() * failAttemptReply.length)]
-    );
-    return false;
-  }
 }
 
 function notHighRoller(msg, offendingUser) {


### PR DESCRIPTION
## What issue is this solving?
Closes #210 

### Description
Updates the `cc!notes`, `cc!addnote` and `cc!verbal` commands to use the new `hasTargetUser()` helper function.

I did these three first because they where the easiest to implement (just changing a function call and removing the old function), most of the other commands use a different method of checking the target user so they might be slightly more complex to refactor, so I'll do them in a separate PR (or a couple).

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? ❌ 
- Any new dependencies to install? ❌ 
- Any special requirements to test? ✔️ 
  - Testing the commands requires the relevant role to execute that command 

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
