### PR TITLE
validate msg.member in messageHandler function

### DIFF
--- a/handlers/messageHandlers.js
+++ b/handlers/messageHandlers.js
@@ -7,13 +7,11 @@ const con = getConnection();
 const client = getClient();
 
 const messageHandler = async (msg) => {
+  if (msg.webhookID) return; // Will be webhookId in v13
+
   if (msg.content.substring(0, 3) === 'cc!') {
     await commandParser(client, con, msg);
-  } else if (
-    msg.author.id != client.user.id &&
-    msg.guild !== null &&
-    !msg.webhookID
-  ) {
+  } else if (msg.member && msg.guild && msg.author.id != client.user.id) {
     await client.commands.get('filter').execute(msg);
   }
 };


### PR DESCRIPTION
## What issue is this solving?
Closes #233

### Description
<!-- Brief description of change -->
Check for the msg.member property in messageHandler so that there is no TypeError in the filter command. Also, refactor check for msg.guild and move web-hook validation to the top.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->
All prior commands should work. It's likely that this will result in no more TypeErrors due to msg.member being null in the filter command.

## Any helpful knowledge/context for the reviewer?
Checking for !msg.guild like this is shown in the discord.js docs here: https://discord.js.org/#/docs/discord.js/v12/examples/moderation

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test? Try various incoming messages (DM, webhook, bot-commands, text)
I have tested basic behaviour: DMs, webhooks, bot-commands and text. Appreciate some further testing to confirm that this will work well.

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
