### PR TITLE
Migrate stats, help and helpcenter commands to v13

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ client.on('guildMemberUpdate', applyMute);
 // Upon channel creation, mutes all users with Muted role in the new channel.
 client.on('channelCreate', extendMutes);
 
-client.on('message', messageHandler);
+client.on('messageCreate', messageHandler);
 
 client.on('messageDelete', logDeletedMessages);
 

--- a/commands/utility/help.js
+++ b/commands/utility/help.js
@@ -169,7 +169,7 @@ module.exports = {
         )
         .addField('Everyone', 'cc!stats, cc!helpcenter, cc!help');
 
-      msg.channel.send(commandsEmbed);
+      msg.channel.send({embeds: [commandsEmbed]});
     }
   },
 };

--- a/commands/utility/helpcenter.js
+++ b/commands/utility/helpcenter.js
@@ -28,7 +28,7 @@ module.exports = {
           'All billing-related queries should be directed to Customer Support.'
         );
 
-      msg.reply(embed);
+      msg.reply({embeds: [embed]});
     }
   },
 };

--- a/commands/utility/stats.js
+++ b/commands/utility/stats.js
@@ -9,15 +9,21 @@ module.exports = {
     const Embed = new Discord.MessageEmbed();
     Embed.setTitle(`Server Stats`);
     const fetchedMembers = await msg.guild.members.fetch();
-    const totalOnline = fetchedMembers.filter(
-      (member) => member.presence.status !== 'offline'
-    ).size;
-    const totalOffline = fetchedMembers.filter(
-      (member) => member.presence.status == 'offline'
-    ).size;
+    const totalOnline = fetchedMembers
+      .filter(
+        (member) => member.presence && member.presence.status !== 'offline'
+      )
+      .size.toString();
+
+    const totalOffline = fetchedMembers
+      .filter(
+        (member) => !member.presence || member.presence.status == 'offline'
+      )
+      .size.toString();
+
     Embed.addField('Online Members', totalOnline);
     Embed.addField('Offline Members', totalOffline);
-    Embed.addField('Total Members', msg.guild.memberCount);
-    msg.channel.send(Embed);
+    Embed.addField('Total Members', msg.guild.memberCount.toString());
+    msg.channel.send({embeds: [Embed]});
   },
 };


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #241 

### Description
<!-- Brief description of change -->
Updates embeds to be compatible with v13
Adjusts stats command to account for `member.presence` possibly being null now.
Uses `messageCreate` event instead of deprecated `message` event.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? ❌ 
- Any new dependencies to install? You might wanna do a fresh `npm install` for testing since some changes were made to the v13 feature branch
- Any special requirements to test? ❌ 
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
