### PR TITLE
Remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "dateformat": "^4.6.3",
         "discord.js": "^13.3.1",
         "dotenv": "^8.6.0",
-        "ms": "^2.1.3",
         "mysql": "^2.18.1"
       },
       "devDependencies": {
@@ -2245,7 +2244,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/mysql": {
       "version": "2.18.1",
@@ -5187,7 +5187,8 @@
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "mysql": {
       "version": "2.18.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "dateformat": "^4.6.3",
     "discord.js": "^13.3.1",
     "dotenv": "^8.6.0",
-    "ms": "^2.1.3",
     "mysql": "^2.18.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
<!-- Brief description of change -->
Removes the `ms` package from our list of dependencies. The package was used in the tempmute and tempban commands, both of which have since been removed.
<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test? No
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
