### PR TITLE
handle unhandled promise rejections with node 16

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const {getClient} = require('./config/client.js');
 const {collectCommands} = require('./config/collectors');
 const {extendMutes} = require('./handlers/channelHandlers.js');
 const {applyMute, createMutedRole} = require('./handlers/guildHandlers.js');
+const {unhandledRejectionHandler} = require('./handlers/errorHandlers');
 const {
   messageHandler,
   logDeletedMessages,
@@ -31,20 +32,7 @@ client.on('messageCreate', messageHandler);
 
 client.on('messageDelete', logDeletedMessages);
 
-process.on('unhandledRejection', async (error) => {
-  try {
-    console.error('Unhandled promise rejection:', error);
-    const channel = client.channels.cache.find(
-      (channel) => channel.name === 'audit-logs'
-    );
-    if (channel) {
-      await channel.send(
-        `UnhandledRejection error. Check logs for more info. Type: ${error.name} Message: ${error.message}`
-      );
-    }
-  } catch (rejectionHandlerErr) {
-    console.error('Error in unhandledRejection handler:', rejectionHandlerErr);
-  }
-});
+// Handles unhandled promise rejections which terminate the node process since node v15.
+process.on('unhandledRejection', unhandledRejectionHandler);
 
 client.login(process.env.DISCORD_SECRET_KEY);

--- a/app.js
+++ b/app.js
@@ -31,4 +31,20 @@ client.on('messageCreate', messageHandler);
 
 client.on('messageDelete', logDeletedMessages);
 
+process.on('unhandledRejection', async (error) => {
+  try {
+    console.error('Unhandled promise rejection:', error);
+    const channel = client.channels.cache.find(
+      (channel) => channel.name === 'audit-logs'
+    );
+    if (channel) {
+      await channel.send(
+        `UnhandledRejection error. Check logs for more info. Type: ${error.name} Message: ${error.message}`
+      );
+    }
+  } catch (rejectionHandlerErr) {
+    console.error('Error in unhandledRejection handler:', rejectionHandlerErr);
+  }
+});
+
 client.login(process.env.DISCORD_SECRET_KEY);

--- a/handlers/errorHandlers.js
+++ b/handlers/errorHandlers.js
@@ -1,0 +1,20 @@
+const {getClient} = require('../config/client.js');
+const client = getClient();
+
+async function unhandledRejectionHandler(error) {
+  try {
+    console.error('Unhandled promise rejection:', error);
+    const channel = client.channels.cache.find(
+      (channel) => channel.name === 'audit-logs'
+    );
+    if (channel) {
+      await channel.send(
+        `UnhandledRejection error. Check logs for more info. Type: ${error.name} Message: ${error.message}`
+      );
+    }
+  } catch (rejectionHandlerErr) {
+    console.error('Error in unhandledRejection handler:', rejectionHandlerErr);
+  }
+}
+
+module.exports = {unhandledRejectionHandler};

--- a/handlers/errorHandlers.js
+++ b/handlers/errorHandlers.js
@@ -1,5 +1,6 @@
 const {getClient} = require('../config/client.js');
 const client = getClient();
+const {MessageEmbed} = require('discord.js');
 
 async function unhandledRejectionHandler(error) {
   try {
@@ -8,9 +9,19 @@ async function unhandledRejectionHandler(error) {
       (channel) => channel.name === 'audit-logs'
     );
     if (channel) {
-      await channel.send(
-        `UnhandledRejection error. Check logs for more info. Type: ${error.name} Message: ${error.message}`
-      );
+      const errorEmbed = new MessageEmbed()
+        .setTitle('UnhandledRejection error')
+        .setColor('RED')
+        .addFields(
+          {name: 'Name', value: error.name},
+          {name: 'Message', value: error.message},
+          {
+            name: 'Info',
+            value: `Path: ${error.path}\nMethod: ${error.method}\nHTTP Status: ${error.httpStatus}`,
+          }
+        )
+        .setTimestamp();
+      await channel.send({embeds: [errorEmbed]});
     }
   } catch (rejectionHandlerErr) {
     console.error('Error in unhandledRejection handler:', rejectionHandlerErr);


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #271

### Description
Adds global error handling for unhandled promise rejections in order to avoid server crash on these errors. Also sends an some error info in a channel to bot developers.

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
