### PR TITLE
Update mute handling for v13

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 const {getClient} = require('./config/client.js');
 const {collectCommands} = require('./config/collectors');
 const {extendMutes} = require('./handlers/channelHandlers.js');
-const {applyMute, createMutedRole} = require('./handlers/guildHandlers.js');
+const {applyMute, createOnMuteRole} = require('./handlers/guildHandlers.js');
 const {unhandledRejectionHandler} = require('./handlers/errorHandlers');
 const {
   messageHandler,
@@ -20,7 +20,7 @@ client.on('ready', () => {
 });
 
 // Adds a Muted role when the bot joins a server
-client.on('guildCreate', createMutedRole);
+client.on('guildCreate', createOnMuteRole);
 
 // Denies reacting and message sending permissions for users with Muted role.
 client.on('roleCreate', applyMute);

--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ client.on('ready', () => {
 client.on('guildCreate', createMutedRole);
 
 // Denies reacting and message sending permissions for users with Muted role.
-client.on('guildMemberUpdate', applyMute);
+client.on('roleCreate', applyMute);
 
 // Upon channel creation, mutes all users with Muted role in the new channel.
 client.on('channelCreate', extendMutes);

--- a/commands/mute/mute.js
+++ b/commands/mute/mute.js
@@ -55,7 +55,7 @@ function canMute(message, args) {
     data.err = 'You cannot mute a moderator or admin.';
     return data;
   }
-  if (data.toMute.roles.cache.some((role) => role.name === 'Muted')) {
+  if (data.toMute.roles.cache.some((role) => role.name === 'On Mute')) {
     data.err = 'This user is already muted.';
     return data;
   }
@@ -73,7 +73,7 @@ function canMute(message, args) {
 function muteUser(message, toMute, reason) {
   // Adds Muted role to user.
   toMute.roles.add(
-    message.guild.roles.cache.find((role) => role.name === 'Muted')
+    message.guild.roles.cache.find((role) => role.name === 'On Mute')
   );
   message.channel.send({
     content: `${toMute} was muted by ${message.member}.\nReason: ${reason}`,

--- a/commands/mute/unmute.js
+++ b/commands/mute/unmute.js
@@ -34,7 +34,7 @@ function canUnmute(message, args) {
     data.err = 'Please provide a user to unmute.';
     return data;
   }
-  if (!data.toUnmute.roles.cache.some((role) => role.name === 'Muted')) {
+  if (!data.toUnmute.roles.cache.some((role) => role.name === 'On Mute')) {
     data.err = 'This user is already unmuted.';
     return data;
   }
@@ -46,7 +46,7 @@ function canUnmute(message, args) {
 function unmuteUser(message, toUnmute) {
   // Removes Muted role from user.
   toUnmute.roles.remove(
-    message.guild.roles.cache.find((role) => role.name === 'Muted')
+    message.guild.roles.cache.find((role) => role.name === 'On Mute')
   );
   message.channel.send({content: `${toUnmute} was unmuted.`});
 

--- a/handlers/channelHandlers.js
+++ b/handlers/channelHandlers.js
@@ -1,7 +1,7 @@
 const extendMutes = (channel) => {
   if (channel.guild != null && channel.isText()) {
     const muted = channel.guild.roles.cache.find(
-      (role) => role.name === 'Muted'
+      (role) => role.name === 'On Mute'
     );
     channel.permissionOverwrites.edit(muted.id, {
       ADD_REACTIONS: false,

--- a/handlers/channelHandlers.js
+++ b/handlers/channelHandlers.js
@@ -1,12 +1,17 @@
 const extendMutes = (channel) => {
-  if (channel.guild != null) {
+  if (channel.guild != null && channel.isText()) {
     const muted = channel.guild.roles.cache.find(
       (role) => role.name === 'Muted'
     );
-    channel.updateOverwrite(muted.id, {
+    channel.permissionOverwrites.edit(muted.id, {
       ADD_REACTIONS: false,
+      ATTACH_FILES: false,
+      CREATE_PUBLIC_THREADS: false,
+      CREATE_PRIVATE_THREADS: false,
       SEND_MESSAGES: false,
+      SEND_MESSAGES_IN_THREADS: false,
       SEND_TTS_MESSAGES: false,
+      USE_APPLICATION_COMMANDS: false,
     });
   }
 };

--- a/handlers/guildHandlers.js
+++ b/handlers/guildHandlers.js
@@ -2,33 +2,32 @@ function createMutedRole(guild) {
   if (guild.available) {
     guild.roles
       .create({
-        data: {
-          name: 'Muted',
-          color: 'DARK_BUT_NOT_BLACK',
-          permissions: [],
-        },
+        name: 'Muted',
+        color: 'DARK_BUT_NOT_BLACK',
+        permissions: [],
       })
       .then(console.log)
       .catch(console.error);
   }
 }
 
-function applyMute(oldMember, newMember) {
-  const muted = newMember.guild.roles.cache.find(
-    (role) => role.name === 'Muted'
-  );
-  newMember.guild.channels.cache.forEach((channel) => {
-    if (
-      channel.type === 'text' &&
-      newMember === channel.members.find((member) => member.id === newMember.id)
-    ) {
-      channel.updateOverwrite(muted.id, {
-        ADD_REACTIONS: false,
-        SEND_MESSAGES: false,
-        SEND_TTS_MESSAGES: false,
-      });
-    }
-  });
+function applyMute(role) {
+  if (role.name == 'Muted') {
+    role.guild.channels.cache.forEach((channel) => {
+      if (channel.isText()) {
+        channel.permissionOverwrites.edit(role.id, {
+          ADD_REACTIONS: false,
+          ATTACH_FILES: false,
+          CREATE_PUBLIC_THREADS: false,
+          CREATE_PRIVATE_THREADS: false,
+          SEND_MESSAGES: false,
+          SEND_MESSAGES_IN_THREADS: false,
+          SEND_TTS_MESSAGES: false,
+          USE_APPLICATION_COMMANDS: false,
+        });
+      }
+    });
+  }
 }
 
 module.exports = {

--- a/handlers/guildHandlers.js
+++ b/handlers/guildHandlers.js
@@ -1,8 +1,8 @@
 function createMutedRole(guild) {
-  if (guild.available) {
+  if (guild.available && !guild.roles.cache.has('On Mute')) {
     guild.roles
       .create({
-        name: 'Muted',
+        name: 'On Mute',
         color: 'DARK_BUT_NOT_BLACK',
         permissions: [],
       })
@@ -12,7 +12,7 @@ function createMutedRole(guild) {
 }
 
 function applyMute(role) {
-  if (role.name == 'Muted') {
+  if (role.name == 'On Mute') {
     role.guild.channels.cache.forEach((channel) => {
       if (channel.isText()) {
         channel.permissionOverwrites.edit(role.id, {

--- a/handlers/guildHandlers.js
+++ b/handlers/guildHandlers.js
@@ -1,5 +1,8 @@
 function createMutedRole(guild) {
-  if (guild.available && !guild.roles.cache.has('On Mute')) {
+  if (
+    guild.available &&
+    !guild.roles.cache.find((role) => role.name === 'On Mute')
+  ) {
     guild.roles
       .create({
         name: 'On Mute',

--- a/handlers/guildHandlers.js
+++ b/handlers/guildHandlers.js
@@ -1,7 +1,7 @@
-function createMutedRole(guild) {
+function createOnMuteRole(guild) {
   if (
     guild.available &&
-    !guild.roles.cache.find((role) => role.name === 'On Mute')
+    !guild.roles.cache.some((role) => role.name === 'On Mute')
   ) {
     guild.roles
       .create({
@@ -34,6 +34,6 @@ function applyMute(role) {
 }
 
 module.exports = {
-  createMutedRole: createMutedRole,
+  createOnMuteRole: createOnMuteRole,
   applyMute: applyMute,
 };


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #273 
Closes #218 

### Description
<!-- Brief description of change -->
- Update role creation and completely refactor muting
- Update new channel muting

I've refactored how the handling works. The role creation remains the same, and the same process still runs when a new channel is created. However, instead of updated channel overwrites every time the `guildMemberUpdate` event runs (which is every nickname change, role change of a user, etc.), it now runs just once when the role is created and creates permanent permission overrides for the `On Mute` role in all channels.

With the new update to threads, I've denied permissions for muted users to create or send messages in threads as well. They also cannot upload files or use slash commands.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->
When we upgrade the actual bot on the community server, this will necessitate completely removing the bot from the server, then re-adding it.

## Any helpful knowledge/context for the reviewer?

**Steps to Test**
1. Remove your bot from the server.
2. Add your bot to the server with Administrator permissions.
3. Ensure that an `On Mute` role is created by the bot upon joining the server (if such a role does not already exist in the server).
4. Ensure that all channels have a permission override where the `On Mute` role cannot send text messages, send messages in threads, etc.
5. When new channels are created, they should also have the override mentioned in step 5.
6. Should not result in any other unexpected behaviour (muted users seeing private channels, etc.)

- Is a re-seeding of the database necessary? No.
- Any new dependencies to install? No.
- Any special requirements to test? Need to be able to mute and unmute users.
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
