### PR TITLE
Make applyMute run when role already exists

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,10 @@
 const {getClient} = require('./config/client.js');
 const {collectCommands} = require('./config/collectors');
 const {extendMutes} = require('./handlers/channelHandlers.js');
-const {applyMute, createOnMuteRole} = require('./handlers/guildHandlers.js');
+const {
+  applyMuteRestrictionsToOnMuteRole,
+  createOnMuteRole,
+} = require('./handlers/guildHandlers.js');
 const {unhandledRejectionHandler} = require('./handlers/errorHandlers');
 const {
   messageHandler,
@@ -23,7 +26,7 @@ client.on('ready', () => {
 client.on('guildCreate', createOnMuteRole);
 
 // Denies reacting and message sending permissions for users with Muted role.
-client.on('roleCreate', applyMute);
+client.on('roleCreate', applyMuteRestrictionsToOnMuteRole);
 
 // Upon channel creation, mutes all users with Muted role in the new channel.
 client.on('channelCreate', extendMutes);

--- a/handlers/channelHandlers.js
+++ b/handlers/channelHandlers.js
@@ -1,9 +1,9 @@
 const extendMutes = (channel) => {
   if (channel.guild != null && channel.isText()) {
-    const muted = channel.guild.roles.cache.find(
+    const onMute = channel.guild.roles.cache.find(
       (role) => role.name === 'On Mute'
     );
-    channel.permissionOverwrites.edit(muted.id, {
+    channel.permissionOverwrites.edit(onMute.id, {
       ADD_REACTIONS: false,
       ATTACH_FILES: false,
       CREATE_PUBLIC_THREADS: false,

--- a/handlers/guildHandlers.js
+++ b/handlers/guildHandlers.js
@@ -11,12 +11,12 @@ function createOnMuteRole(guild) {
         .catch(console.error);
     } else {
       const onMute = guild.roles.cache.find((role) => role.name === 'On Mute');
-      applyMute(onMute);
+      applyMuteRestrictionsToOnMuteRole(onMute);
     }
   }
 }
 
-function applyMute(role) {
+function applyMuteRestrictionsToOnMuteRole(role) {
   if (role.name == 'On Mute') {
     role.guild.channels.cache.forEach((channel) => {
       if (channel.isText()) {
@@ -37,5 +37,5 @@ function applyMute(role) {
 
 module.exports = {
   createOnMuteRole: createOnMuteRole,
-  applyMute: applyMute,
+  applyMuteRestrictionsToOnMuteRole: applyMuteRestrictionsToOnMuteRole,
 };

--- a/handlers/guildHandlers.js
+++ b/handlers/guildHandlers.js
@@ -1,16 +1,18 @@
 function createOnMuteRole(guild) {
-  if (
-    guild.available &&
-    !guild.roles.cache.some((role) => role.name === 'On Mute')
-  ) {
-    guild.roles
-      .create({
-        name: 'On Mute',
-        color: 'DARK_BUT_NOT_BLACK',
-        permissions: [],
-      })
-      .then(console.log)
-      .catch(console.error);
+  if (guild.available) {
+    if (!guild.roles.cache.some((role) => role.name === 'On Mute')) {
+      guild.roles
+        .create({
+          name: 'On Mute',
+          color: 'DARK_BUT_NOT_BLACK',
+          permissions: [],
+        })
+        .then(console.log)
+        .catch(console.error);
+    } else {
+      const onMute = guild.roles.cache.find((role) => role.name === 'On Mute');
+      applyMute(onMute);
+    }
   }
 }
 


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #280 

### Description
<!-- Brief description of change -->
`applyMute()` was previously only running if the bot itself created the `On Mute` role. However, with the change to make the bot skip this role creation process if the role already existed in the server this meant message sending permissions were not being denied to the `On Mute` role in each channel. These changes fix that by having `applyMute()` run whether or not the role was created by the bot.
<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test? Need to be able to view Permissions section of channel settings
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
