### PR TITLE
move bot error channel config to env file

### DIFF
--- a/handlers/errorHandlers.js
+++ b/handlers/errorHandlers.js
@@ -6,7 +6,7 @@ async function unhandledRejectionHandler(error) {
   try {
     console.error('Unhandled promise rejection:', error);
     const channel = client.channels.cache.find(
-      (channel) => channel.name === 'audit-logs'
+      (channel) => channel.name === process.env.BOT_ERROR_CHANNEL
     );
     if (channel) {
       const errorEmbed = new MessageEmbed()

--- a/handlers/errorHandlers.js
+++ b/handlers/errorHandlers.js
@@ -5,9 +5,7 @@ const {MessageEmbed} = require('discord.js');
 async function unhandledRejectionHandler(error) {
   try {
     console.error('Unhandled promise rejection:', error);
-    const channel = client.channels.cache.find(
-      (channel) => channel.name === process.env.BOT_ERROR_CHANNEL
-    );
+    const channel = client.channels.cache.get(process.env.BOT_ERROR_CHANNEL_ID);
     if (channel) {
       const errorEmbed = new MessageEmbed()
         .setTitle('UnhandledRejection error')


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #283 

### Description
Moves setting of the channel for bot errors to the .env file.

## Any helpful knowledge/context for the reviewer?
Set the channel in the .env file with the variable BOT_ERROR_CHANNEL_ID. You can add the line below to the .env file:
BOT_ERROR_CHANNEL_ID=ID_FOR_audit-logs

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test? No
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
