### PR TITLE
use separate fields for notes/infractions records

### DIFF
--- a/commands/moderation/notes.js
+++ b/commands/moderation/notes.js
@@ -61,8 +61,8 @@ function notesLog(msg, targetUser, notes) {
         iconURL: `https://cdn.discordapp.com/avatars/${targetUser.user.id}/${targetUser.user.avatar}.png`,
       })
       .setColor(embedFlair[Math.floor(Math.random() * embedFlair.length)])
-      .addField(`Total`, `${totalNotes}`)
-      .addField(`Latest Notes: `, listOfNotes.join('\n'))
+      .setDescription(`Total: ${totalNotes}`)
+      .addFields(...listOfNotes)
       .setTimestamp()
       .setFooter({text: `${msg.guild.name}`});
 
@@ -115,11 +115,12 @@ function parseNotes(msg, notes) {
   const notesWithTimes = [];
   for (let i = 0; i < moderatorList.length; i++) {
     if (validList[i])
-      notesWithTimes.push(
-        `**ID: ${idList[i]}** • ${msg.guild.members.cache.get(
-          moderatorList[i]
-        )}: *${noteList[i]}* • ${timeSinceNote[i]} *ago*`
-      );
+      notesWithTimes.push({
+        name: `ID: ${idList[i]}   ${timeSinceNote[i]} ago`,
+        value: `${msg.guild.members.cache.get(moderatorList[i])}: ${
+          noteList[i]
+        }`,
+      });
   }
   return notesWithTimes;
 }

--- a/commands/utility/infractions.js
+++ b/commands/utility/infractions.js
@@ -55,7 +55,6 @@ function infractionLog(msg, targetUser, infractions) {
     '#d3b99f',
     '#6e6a6f',
   ];
-
   if (totalInfractions) {
     const infractionsEmbed = new Discord.MessageEmbed()
       .setAuthor({
@@ -63,8 +62,8 @@ function infractionLog(msg, targetUser, infractions) {
         iconURL: `https://cdn.discordapp.com/avatars/${targetUser.user.id}/${targetUser.user.avatar}.png`,
       })
       .setColor(embedFlair[Math.floor(Math.random() * embedFlair.length)])
-      .addField(`Total`, `${totalInfractions}`)
-      .addField(`Latest infractions: `, listOfInfractions.join('\n'))
+      .setDescription(`Total: ${totalInfractions}`)
+      .addFields(...listOfInfractions)
       .setTimestamp()
       .setFooter({text: `${msg.guild.name}`});
 
@@ -121,9 +120,10 @@ function parseInfractions(infractions) {
   const reasonsWithTimes = [];
   for (let i = 0; i < reasonsList.length; i++) {
     if (validList[i])
-      reasonsWithTimes.push(
-        `**ID: ${idList[i]}** • ${actionList[i]} • *${reasonsList[i]}* • ${timeSinceInfraction[i]} *ago*`
-      );
+      reasonsWithTimes.push({
+        name: `ID: ${idList[i]}   ${actionList[i]}   ${timeSinceInfraction[i]} ago`,
+        value: `${reasonsList[i]}`,
+      });
   }
   return reasonsWithTimes;
 }


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #144

### Description
Uses a separate embed field for each record in the notes and infractions commands. This allows much more data than the previous limit which was 1024 chars for all records. Now the limit is a max of 25 records (fields) which each can contain 1024 chars or a total of 6000 chars for the entire embed.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?
A solution that is using an embed needs to stay within discord.js embed limits: https://discordjs.guide/popular-topics/embeds.html#embed-limits

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test? No
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
