### PR TITLE
use date-fns for notes/infractions time-ago

### DIFF
--- a/commands/moderation/notes.js
+++ b/commands/moderation/notes.js
@@ -1,5 +1,6 @@
 const Discord = require('discord.js');
 const {hasTargetUser} = require('../../helpers/hasTargetUser');
+const {formatDistanceToNow} = require('date-fns');
 
 module.exports = {
   name: 'notes',
@@ -89,26 +90,7 @@ function parseNotes(msg, notes) {
   const noteList = allNotes.map((note) => note[3]);
   const validList = allNotes.map((note) => note[4]);
 
-  // Format timestamps to work backwards from current time
-  // First convert to millisecs, then compare with current time
-  timestampList.forEach((time, idx) => (timestampList[idx] = Date.parse(time)));
-  const now = Date.now();
-  const timeSinceNote = timestampList.map((time) => now - time); // elapsed time
-  timeSinceNote.forEach((time, idx) => {
-    const seconds = time / 1000;
-    const minutes = seconds / 60;
-    const hours = minutes / 60;
-    const days = hours / 24;
-    if (Math.floor(days) > 0) {
-      timeSinceNote[idx] = [`${Math.floor(days)}d ${Math.round(days % 24)}h`];
-    } else if (Math.floor(hours) > 0) {
-      timeSinceNote[idx] = [`${Math.floor(hours)}h ${Math.round(hours % 60)}m`];
-    } else {
-      timeSinceNote[idx] = [
-        `${Math.floor(minutes)}m ${Math.round(minutes % 60)}s`,
-      ];
-    }
-  });
+  const timeSinceNote = timestampList.map((time) => formatDistanceToNow(time));
 
   // Join noteList with timeSinceNote
   // This lets us print out the embedded message so much better

--- a/commands/utility/infractions.js
+++ b/commands/utility/infractions.js
@@ -1,4 +1,5 @@
 const Discord = require('discord.js');
+const {formatDistanceToNow} = require('date-fns');
 const {hasTargetUser} = require('../../helpers/hasTargetUser');
 
 module.exports = {
@@ -91,30 +92,9 @@ function parseInfractions(infractions) {
   const actionList = infractionsList.map((infraction) => infraction[3]);
   const validList = infractionsList.map((infraction) => infraction[4]);
 
-  // Format timestamps to work backwards from current time
-  // First convert to millisecs, then compare with current time
-  timestampList.forEach((time, idx) => (timestampList[idx] = Date.parse(time)));
-  const now = Date.now();
-  const timeSinceInfraction = timestampList.map((time) => now - time); // elapsed time
-  timeSinceInfraction.forEach((time, idx) => {
-    const seconds = time / 1000;
-    const minutes = seconds / 60;
-    const hours = minutes / 60;
-    const days = hours / 24;
-    if (Math.floor(days) > 0) {
-      timeSinceInfraction[idx] = [
-        `${Math.floor(days)}d ${Math.round(days % 24)}h`,
-      ];
-    } else if (Math.floor(hours) > 0) {
-      timeSinceInfraction[idx] = [
-        `${Math.floor(hours)}h ${Math.round(hours % 60)}m`,
-      ];
-    } else {
-      timeSinceInfraction[idx] = [
-        `${Math.floor(minutes)}m ${Math.round(minutes % 60)}s`,
-      ];
-    }
-  });
+  const timeSinceInfraction = timestampList.map((time) =>
+    formatDistanceToNow(time)
+  );
 
   // Join reasonsList with timeSinceInfraction
   // This lets us print out the embedded message so much better

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "bad-words": "^3.0.4",
+        "date-fns": "^2.28.0",
         "dateformat": "^4.6.3",
         "discord.js": "^13.6.0",
         "dotenv": "^8.6.0",
@@ -783,6 +784,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/dateformat": {
@@ -3971,6 +3984,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dateformat": {
       "version": "4.6.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "bad-words": "^3.0.4",
+    "date-fns": "^2.28.0",
     "dateformat": "^4.6.3",
     "discord.js": "^13.6.0",
     "dotenv": "^8.6.0",


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #126

### Description
There was repetitive code in infractions and notes to print how long ago an event occurred. This refactor uses a function from the date-fns library to simplify the code. Also, in case we need additional time related functionality date-fns is one of the better options.

Discovered during refactoring:
There also appears to be a bug in current code related to calculating parts of the time string. For example in the code below how seconds are calculated appears to be incorrect. If minutes is 2.5 this will calculate 3 sec instead of 30 sec:
```js
timeSinceNote[idx] = [
        `${Math.floor(minutes)}m ${Math.round(minutes % 60)}s`,
      ];
````
Using date-fns library solves this issue and simplifies our code.

Npm info: https://www.npmjs.com/package/date-fns
Library docs: https://date-fns.org/

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? Yes, date-fns.
- Any special requirements to test?
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
