### PR TITLE
Create timeout command

### DIFF
--- a/commands/moderation/timeout.js
+++ b/commands/moderation/timeout.js
@@ -23,7 +23,7 @@ module.exports = {
     try {
       await dmTheUser(msg, toTimeout, duration, reason);
     } catch (e) {
-      return msg.reply(`${e.name}: ${e.message}`);
+      return msg.channel.send(`${e.name}: ${e.message}`);
     }
   },
 };

--- a/commands/moderation/timeout.js
+++ b/commands/moderation/timeout.js
@@ -74,7 +74,7 @@ function canTimeout(msg, args) {
     data.err = 'Please provide a duration.';
     return data;
   }
-  if (!data.duration.match(/^\d+.?\d*[smhdw]$/)) {
+  if (!data.duration.match(/^\d+\.?\d*[smhdw]$/)) {
     data.err =
       'Please provide a valid duration. Format should be `<number><s|m|h|d|w>`.';
     return data;
@@ -143,7 +143,7 @@ function recordTimeoutInDB(msg, toTimeout, duration, reason, con) {
 
   con.query(escaped, function (err, result) {
     if (err) {
-      console.log(err);
+      console.error(err);
       msg.channel.send({
         content: `I timed out ${toTimeout} but writing to the db failed!`,
       });

--- a/commands/moderation/timeout.js
+++ b/commands/moderation/timeout.js
@@ -1,0 +1,175 @@
+const Discord = require('discord.js');
+const dateformat = require('dateformat');
+const ms = require('ms');
+const {verifyReasonLength} = require('../../helpers/stringHelpers');
+
+module.exports = {
+  name: 'timeout',
+  description: 'Timeout a user',
+  guildOnly: true,
+  staffOnly: true,
+  minRole: 'Moderator',
+
+  async execute(msg, args, con) {
+    const {status, err, toTimeout, duration, reason} = canTimeout(msg, args);
+    if (!status) {
+      return msg.reply({content: err});
+    }
+
+    if (!verifyReasonLength(msg.content, msg)) return;
+
+    timeoutUser(msg, toTimeout, duration, reason);
+    auditLogTimeout(msg, toTimeout, duration, reason);
+    recordTimeoutInDB(msg, toTimeout, duration, reason, con);
+    try {
+      await dmTheUser(msg, toTimeout, duration, reason);
+    } catch (e) {
+      return msg.reply(`${e.name}: ${e.message}`);
+    }
+  },
+};
+
+// Validates data.
+function canTimeout(msg, args) {
+  const data = {
+    status: false,
+    err: null,
+    toTimeout: null,
+    duration: null,
+    reason: null,
+  };
+
+  // Check if targeted user is valid and can be timed out.
+  data.toTimeout =
+    msg.mentions.members.first() || msg.guild.members.cache.get(args[0]);
+  if (!data.toTimeout) {
+    data.err = 'Please provide a user to timeout.';
+    return data;
+  }
+  if (data.toTimeout === msg.member) {
+    data.err = 'You cannot timeout yourself.';
+    return data;
+  }
+  if (
+    data.toTimeout.roles.cache.some(
+      (role) =>
+        role.name === 'Moderator' ||
+        role.name === 'Admin' ||
+        role.name === 'Super Admin'
+    )
+  ) {
+    data.err = 'You cannot timeout a moderator or admin.';
+    return data;
+  }
+  if (
+    data.toTimeout.communicationDisabledUntilTimestamp !== null &&
+    data.toTimeout.communicationDisabledUntil > Date.now()
+  ) {
+    data.err = 'This user is already timed out.';
+    return data;
+  }
+
+  // Check if duration is valid.
+  data.duration = args[1];
+  if (!data.duration) {
+    data.err = 'Please provide a duration.';
+    return data;
+  }
+  if (!data.duration.match(/^\d+.?\d*[smhdw]$/)) {
+    data.err =
+      'Please provide a valid duration. Format should be `<number><s|m|h|d|w>`.';
+    return data;
+  }
+  if (ms(data.duration) > ms('28d')) {
+    data.err = 'Please enter a duration less than 28 days.';
+    return data;
+  }
+
+  // Check if reason is valid.
+  data.reason = args.slice(2).join(' ');
+  if (data.reason === '') {
+    data.err = 'Please provide a reason for the timeout.';
+    return data;
+  }
+
+  // Return valid data.
+  data.status = true;
+  return data;
+}
+
+// Puts a user in timeout.
+function timeoutUser(msg, toTimeout, duration, reason) {
+  const durationInMs = ms(duration);
+  toTimeout.timeout(durationInMs, reason);
+
+  msg.reply(`${toTimeout} has been timed out for ${duration}.`);
+}
+
+// Sends message to #audit-logs.
+function auditLogTimeout(msg, toTimeout, duration, reason) {
+  const auditLogEmbed = new Discord.MessageEmbed()
+    .setColor('#0099ff')
+    .setTitle(
+      `${toTimeout.user.username}#${toTimeout.user.discriminator} was timed out by ${msg.author.tag} for ${duration}.`
+    )
+    .addField('Reason', reason)
+    .setTimestamp()
+    .setFooter({text: `${msg.guild.name}`})
+    .setThumbnail(
+      `https://cdn.discordapp.com/avatars/${toTimeout.user.id}/${toTimeout.user.avatar}.png`
+    );
+
+  msg.guild.channels.cache
+    .find((channel) => channel.name === 'audit-logs')
+    .send({embeds: [auditLogEmbed]});
+}
+
+// Records timeout in infractions and mod_log tables.
+function recordTimeoutInDB(msg, toTimeout, duration, reason, con) {
+  const now = new Date();
+  const timestamp = dateformat(now, 'yyyy-mm-dd HH:MM:ss');
+
+  const sql = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) VALUES (?, ?, 'timeout', ?, ?, true, ?);
+  INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason)
+  VALUES (?, ?, ?, ?, ?);`;
+
+  const values = [
+    timestamp,
+    toTimeout.id,
+    duration,
+    reason,
+    msg.author.id,
+    timestamp,
+    msg.author.id,
+    msg.content,
+    duration,
+    reason,
+  ];
+  const escaped = con.format(sql, values);
+
+  con.query(escaped, function (err, result) {
+    if (err) {
+      console.log(err);
+      msg.channel.send({
+        content: `I timed out ${toTimeout} but writing to the db failed!`,
+      });
+    } else {
+      console.log(
+        '1 record inserted into infractions, 1 record inserted into mod_log.'
+      );
+    }
+  });
+}
+
+// Attempts to DM the user with the reason for the timeout.
+async function dmTheUser(msg, toTimeout, duration, reason) {
+  const verbalEmbed = new Discord.MessageEmbed()
+    .setColor('#0099ff')
+    .setTitle(`You have been timed out for ${ms(ms(duration), {long: true})}.`)
+    .addField('Reason', reason)
+    .setTimestamp()
+    .setFooter({text: `${msg.guild.name}`})
+    .setThumbnail(msg.guild.iconURL({dynamic: true}));
+
+  await toTimeout.user.send({embeds: [verbalEmbed]});
+}

--- a/commands/moderation/timeout.js
+++ b/commands/moderation/timeout.js
@@ -79,6 +79,10 @@ function canTimeout(msg, args) {
       'Please provide a valid duration. Format should be `<number><s|m|h|d|w>`.';
     return data;
   }
+  if (ms(data.duration) <= 0) {
+    data.err = 'You must specify a duration greater than 0.';
+    return data;
+  }
   if (ms(data.duration) > ms('28d')) {
     data.err = 'Please enter a duration less than 28 days.';
     return data;

--- a/commands/moderation/timeout.js
+++ b/commands/moderation/timeout.js
@@ -1,5 +1,4 @@
 const Discord = require('discord.js');
-const dateformat = require('dateformat');
 const ms = require('ms');
 const {verifyReasonLength} = require('../../helpers/stringHelpers');
 
@@ -126,20 +125,15 @@ function auditLogTimeout(msg, toTimeout, duration, reason) {
 
 // Records timeout in infractions and mod_log tables.
 function recordTimeoutInDB(msg, toTimeout, duration, reason, con) {
-  const now = new Date();
-  const timestamp = dateformat(now, 'yyyy-mm-dd HH:MM:ss');
-
-  const sql = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) VALUES (?, ?, 'timeout', ?, ?, true, ?);
+  const sql = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) VALUES (now(), ?, 'timeout', ?, ?, true, ?);
   INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason)
-  VALUES (?, ?, ?, ?, ?);`;
+  VALUES (now(), ?, ?, ?, ?);`;
 
   const values = [
-    timestamp,
     toTimeout.id,
     duration,
     reason,
     msg.author.id,
-    timestamp,
     msg.author.id,
     msg.content,
     duration,

--- a/config/slashCommandPermissions.js
+++ b/config/slashCommandPermissions.js
@@ -16,6 +16,7 @@ const commandRoles = new Map([
   ['addnote', allStaffRoles],
   ['removenote', moderatorRoles],
   ['clearmessages', moderatorRoles],
+  ['timeout', moderatorRoles],
 ]);
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "discord-api-types": "^0.28.0",
         "discord.js": "^13.6.0",
         "dotenv": "^8.6.0",
+        "ms": "^2.1.3",
         "mysql2": "^2.3.3"
       },
       "devDependencies": {
@@ -853,6 +854,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/decompress-response": {
       "version": "3.3.0",
@@ -2240,16 +2247,15 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mysql2": {
       "version": "2.3.3",
@@ -4098,6 +4104,14 @@
       "dev": true,
       "requires": {
         "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "decompress-response": {
@@ -5141,16 +5155,15 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "mysql2": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "discord-api-types": "^0.28.0",
     "discord.js": "^13.6.0",
     "dotenv": "^8.6.0",
+    "ms": "^2.1.3",
     "mysql2": "^2.3.3"
   },
   "devDependencies": {

--- a/slash-commands/moderation/timeout.js
+++ b/slash-commands/moderation/timeout.js
@@ -45,10 +45,9 @@ module.exports = {
     ),
 
   async execute(interaction) {
-    let toTimeout;
-    interaction.guild.members
-      .fetch(await interaction.options.getUser('user'))
-      .then((result) => (toTimeout = result));
+    const toTimeout = await interaction.guild.members.fetch(
+      await interaction.options.getUser('user')
+    );
     const durationInteger = await interaction.options.getInteger(
       'durationinteger'
     );

--- a/slash-commands/moderation/timeout.js
+++ b/slash-commands/moderation/timeout.js
@@ -61,7 +61,7 @@ module.exports = {
         await timeoutUser(interaction, toTimeout, duration, reason);
       } catch (e) {
         console.error(e);
-        interaction.reply(
+        return interaction.reply(
           'Something went wrong while trying to timeout the user.'
         );
       }

--- a/slash-commands/moderation/timeout.js
+++ b/slash-commands/moderation/timeout.js
@@ -104,6 +104,10 @@ function canTimeout(interaction, toTimeout, duration, reason) {
   }
 
   // Check if duration is valid.
+  if (ms(duration) <= 0) {
+    interaction.reply('You must specify a duration greater than 0.');
+    return false;
+  }
   if (ms(duration) > ms('28d') - 1) {
     interaction.reply('Please enter a duration less than 28 days.');
     return false;

--- a/slash-commands/moderation/timeout.js
+++ b/slash-commands/moderation/timeout.js
@@ -1,0 +1,181 @@
+const Discord = require('discord.js');
+const dateformat = require('dateformat');
+const ms = require('ms');
+const {verifyReasonLength} = require('../../helpers/stringHelpers');
+const {SlashCommandBuilder} = require('@discordjs/builders');
+const {promisePool} = require('../../config/db');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('timeout')
+    .setDefaultPermission(false)
+    .setDescription('Timeout a user')
+    .addUserOption((option) =>
+      option
+        .setName('user')
+        .setDescription('The user to timeout')
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('duration')
+        .setDescription(
+          'How long the user should be timed out as <number><s|m|h|d|w>'
+        )
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('reason')
+        .setDescription('The reason for the timeout')
+        .setRequired(true)
+    ),
+
+  async execute(interaction) {
+    let toTimeout;
+    interaction.guild.members
+      .fetch(await interaction.options.getUser('user'))
+      .then((result) => (toTimeout = result));
+    const duration = await interaction.options.getString('duration');
+    const reason = await interaction.options.getString('reason');
+
+    if (canTimeout(interaction, toTimeout, duration, reason)) {
+      try {
+        await timeoutUser(interaction, toTimeout, duration, reason);
+      } catch (e) {
+        console.log(e);
+        interaction.reply(
+          'Something went wrong while trying to timeout the user.'
+        );
+      }
+      await auditLogTimeout(interaction, toTimeout, duration, reason);
+      await recordTimeoutInDB(interaction, toTimeout, duration, reason);
+      try {
+        await dmTheUser(interaction, toTimeout, duration, reason);
+      } catch (e) {
+        console.log(e);
+        interaction.reply(`${e.name}: ${e.message}`);
+      }
+    }
+  },
+};
+
+// Validates data.
+function canTimeout(interaction, toTimeout, duration, reason) {
+  if (toTimeout === interaction.member) {
+    interaction.reply('You cannot timeout yourself.');
+    return false;
+  }
+  if (
+    toTimeout.roles.cache.some(
+      (role) =>
+        role.name === 'Moderator' ||
+        role.name === 'Admin' ||
+        role.name === 'Super Admin'
+    )
+  ) {
+    interaction.reply('You cannot timeout a moderator or admin.');
+    return false;
+  }
+  if (
+    toTimeout.communicationDisabledUntilTimestamp !== null &&
+    toTimeout.communicationDisabledUntil > Date.now()
+  ) {
+    interaction.reply('This user is already timed out.');
+    return false;
+  }
+
+  // Check if duration is valid.
+  if (!duration.match(/^\d+.?\d*[smhdw]$/)) {
+    interaction.reply(
+      'Please provide a valid duration. Format should be `<number><s|m|h|d|w>`.'
+    );
+    return false;
+  }
+  if (ms(duration) > ms('28d')) {
+    interaction.reply('Please enter a duration less than 28 days.');
+    return false;
+  }
+
+  // Check if reason is of a valid length.
+  if (!verifyReasonLength(reason, interaction)) return false;
+
+  return true;
+}
+
+// Puts a user in timeout.
+async function timeoutUser(interaction, toTimeout, duration, reason) {
+  const durationInMs = ms(duration);
+  toTimeout.timeout(durationInMs, reason);
+
+  await interaction.reply(`${toTimeout} has been timed out for ${duration}.`);
+}
+
+// Sends message to #audit-logs.
+async function auditLogTimeout(interaction, toTimeout, duration, reason) {
+  const auditLogEmbed = new Discord.MessageEmbed()
+    .setColor('#0099ff')
+    .setTitle(
+      `${toTimeout.user.username}#${toTimeout.user.discriminator} was timed out by ${interaction.member.user.tag} for ${duration}.`
+    )
+    .addField('Reason', reason)
+    .setTimestamp()
+    .setFooter({text: `${interaction.guild.name}`})
+    .setThumbnail(
+      `https://cdn.discordapp.com/avatars/${toTimeout.user.id}/${toTimeout.user.avatar}.png`
+    );
+
+  await interaction.guild.channels.cache
+    .find((channel) => channel.name === 'audit-logs')
+    .send({embeds: [auditLogEmbed]});
+}
+
+// Records timeout in infractions and mod_log tables.
+async function recordTimeoutInDB(interaction, toTimeout, duration, reason) {
+  const now = new Date();
+  const timestamp = dateformat(now, 'yyyy-mm-dd HH:MM:ss');
+
+  const infractionsSQL = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) VALUES (?, ?, 'timeout', ?, ?, true, ?);`;
+  const infractionsValues = [
+    timestamp,
+    toTimeout.user.id,
+    duration,
+    reason,
+    interaction.member.user.id,
+  ];
+
+  const modLogSQL = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) VALUES (?, ?, ?, ?, ?);`;
+  const modLogValues = [
+    timestamp,
+    interaction.member.user.id,
+    `timed out user ${toTimeout.user.id}`,
+    duration,
+    reason,
+  ];
+
+  try {
+    await promisePool.execute(infractionsSQL, infractionsValues);
+    await promisePool.execute(modLogSQL, modLogValues);
+    console.log(
+      '1 record inserted into infractions, 1 record inserted into mod_log.'
+    );
+  } catch (err) {
+    interaction.channel.send({
+      content: `I timed out ${toTimeout} but writing to the db failed!`,
+    });
+    throw new Error(err.message);
+  }
+}
+
+// Attempts to DM the user with the reason for the timeout.
+async function dmTheUser(interaction, toTimeout, duration, reason) {
+  const verbalEmbed = new Discord.MessageEmbed()
+    .setColor('#0099ff')
+    .setTitle(`You have been timed out for ${ms(ms(duration), {long: true})}.`)
+    .addField('Reason', reason)
+    .setTimestamp()
+    .setFooter({text: `${interaction.guild.name}`})
+    .setThumbnail(interaction.guild.iconURL({dynamic: true}));
+
+  await toTimeout.user.send({embeds: [verbalEmbed]});
+}

--- a/slash-commands/moderation/timeout.js
+++ b/slash-commands/moderation/timeout.js
@@ -1,7 +1,7 @@
 const Discord = require('discord.js');
 const ms = require('ms');
 const {verifyReasonLength} = require('../../helpers/stringHelpers');
-const {sendToAuditLogs} = require('../../helpers/sendToAuditLogs');
+const {sendToAuditLogsChannel} = require('../../helpers/sendToAuditLogs');
 const {SlashCommandBuilder} = require('@discordjs/builders');
 const {promisePool} = require('../../config/db');
 
@@ -113,10 +113,11 @@ async function timeoutUser(interaction, toTimeout, duration, reason) {
 
 // Sends message to #audit-logs.
 async function auditLogTimeout(interaction, toTimeout, duration, reason) {
-  const color = '#0099ff';
-  const title = `${toTimeout.user.username}#${toTimeout.user.discriminator} was timed out by ${interaction.member.user.tag} for ${duration}.`;
-  const description = `**Reason:** ${reason}`;
-  sendToAuditLogs(interaction, {color, title, description});
+  await sendToAuditLogsChannel(interaction, {
+    color: '#0099ff',
+    titleMsg: `${toTimeout.user.username}#${toTimeout.user.discriminator} was timed out by ${interaction.member.user.tag} for ${duration}.`,
+    description: `**Reason:** ${reason}`,
+  });
 }
 
 // Records timeout in infractions and mod_log tables.

--- a/slash-commands/moderation/timeout.js
+++ b/slash-commands/moderation/timeout.js
@@ -70,8 +70,7 @@ module.exports = {
       try {
         await dmTheUser(interaction, toTimeout, duration, reason);
       } catch (e) {
-        console.error(e);
-        interaction.reply(`${e.name}: ${e.message}`);
+        interaction.channel.send(`${e.name}: ${e.message}`);
       }
     }
   },


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #235 

### Description
<!-- Brief description of change -->
* Added timeout command (both non-slash and slash versions).
* The command times out a user using Discord's new timeout functionality, DMs the user, records the event in audit-logs, and records the event in both the infractions and mod_log tables.
* Mods and above cannot be timed out. Timed out users are automatically un-timed out after the specified time has elapsed (we don't need to code this on our end).
* May still need to discuss the following, which was on the linked issue:
> We need to discuss how this may impact how users contact server staff. As we are currently considering moving to a channel-based ModMail-like tool, that would render users in timeout unable to contact staff.
<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? **No**
- Any new dependencies to install? **Yes**
- Any special requirements to test? **The usual, test with different roles to see effects. Minimum role required is Moderator.**
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
