### PR TITLE
add audit log helper target user thumbnail option

### DIFF
--- a/helpers/sendToAuditLogs.js
+++ b/helpers/sendToAuditLogs.js
@@ -1,27 +1,30 @@
 const Discord = require('discord.js');
 
 /**
- * Sends a message to the audit-logs channel
- * @param {any} interaction = Discord.js interaction
+ * Sends a message to the audit-logs channel.
+ * Include a target user object as the optional targetUser parameter in order
+ * to generate a thumbnail of the target user.
+ * @param {any} interaction Discord.js interaction
  * @param {Object} configObj Embed config object
  * @param {string} configObj.color Color of the embed
  * @param {string} configObj.titleMsg Title msg for embed
  * @param {string} [configObj.description] Description for embed
+ * @param {Object} [configObj.targetUser] User object for the thumbnail
  */
-
 async function sendToAuditLogsChannel(
   interaction,
-  {color, titleMsg, description = ''}
+  {color, titleMsg, description = '', targetUser = null}
 ) {
   const channel = await interaction.guild.channels.cache.find(
     (channel) => channel.name === 'audit-logs'
   );
-
   const clearMsgEmbed = new Discord.MessageEmbed()
     .setColor(color)
     .setTitle(titleMsg)
     .setThumbnail(
-      `https://cdn.discordapp.com/avatars/${interaction.user.id}/${interaction.user.avatar}.png`
+      targetUser
+        ? `https://cdn.discordapp.com/avatars/${targetUser.id}/${targetUser.avatar}.png`
+        : `https://cdn.discordapp.com/avatars/${interaction.user.id}/${interaction.user.avatar}.png`
     )
     .setDescription(description)
     .setTimestamp()

--- a/slash-commands/moderation/removenote.js
+++ b/slash-commands/moderation/removenote.js
@@ -26,6 +26,7 @@ module.exports = {
         color: '#0099ff',
         titleMsg: `${interaction.user.tag} removed a note from ${targetUser.username}#${targetUser.discriminator}`,
         description: `Note #${noteId}`,
+        targetUser,
       });
       await noteResponse(interaction, noteId, targetUser);
     } catch (err) {

--- a/slash-commands/moderation/timeout.js
+++ b/slash-commands/moderation/timeout.js
@@ -137,6 +137,7 @@ async function auditLogTimeout(interaction, toTimeout, duration, reason) {
       long: true,
     })}.`,
     description: `**Reason:** ${reason}`,
+    targetUser: toTimeout.user,
   });
 }
 

--- a/slash-commands/moderation/verbal.js
+++ b/slash-commands/moderation/verbal.js
@@ -37,6 +37,7 @@ module.exports = {
         color: '#f1d302',
         titleMsg: `${targetUser.tag} was verballed by ${interaction.user.tag}:`,
         description: reason,
+        targetUser,
       });
       return await interaction.reply({
         content: `${interaction.user} just verballed ${targetUser}`,


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #316

### Description
<!-- Brief description of change -->
Adds an optional targetUser property to to audit log helper function. If the targetUser is included, the function will now generate a thumbnail of that user. If it's not included, it will generate a thumbnail of the interaction user (usually the moderator). Implemented this functionality in those slash commands that were already including a thumbnail of the target user for the text based commands.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test?
  - (e.g., admin perms, alt account, etc.)

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
