### PR TITLE
Add ban and unban slash commands

### DIFF
--- a/config/slashCommandPermissions.js
+++ b/config/slashCommandPermissions.js
@@ -11,15 +11,17 @@ const allStaffRoles = [
 const moderatorRoles = [ID_MODERATOR, ID_ADMIN, ID_SUPER_ADMIN];
 
 const commandRoles = new Map([
-  ['ping', allStaffRoles],
-  ['notes', allStaffRoles],
   ['addnote', allStaffRoles],
-  ['removenote', moderatorRoles],
+  ['notes', allStaffRoles],
+  ['ping', allStaffRoles],
+  ['ban', moderatorRoles],
   ['clearmessages', moderatorRoles],
   ['kick', moderatorRoles],
-  ['verbal', moderatorRoles],
-  ['timeout', moderatorRoles],
+  ['removenote', moderatorRoles],
   ['removetimeout', moderatorRoles],
+  ['timeout', moderatorRoles],
+  ['unban', moderatorRoles],
+  ['verbal', moderatorRoles],
 ]);
 
 /**

--- a/slash-commands/moderation/ban.js
+++ b/slash-commands/moderation/ban.js
@@ -1,0 +1,111 @@
+const Discord = require('discord.js');
+const {SlashCommandBuilder} = require('@discordjs/builders');
+const {promisePool} = require('../../config/db');
+const {sendToAuditLogsChannel} = require('../../helpers/sendToAuditLogs');
+const {
+  isServerStaff,
+  sendNoTargetStaffReply,
+} = require('../../helpers/validation');
+const {verifyReasonLength} = require('../../helpers/stringHelpers');
+
+const banIntro = "You've been banned for the following reason: ```";
+const unbanRequest =
+  ' ``` If you wish to challenge this ban, please submit a response in this Google Form: https://forms.gle/KxTMhPbi866r2FEz5';
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ban')
+    .setDefaultPermission(false)
+    .setDescription('Bans a user')
+    .addUserOption((option) =>
+      option.setName('target').setDescription('The user').setRequired(true)
+    )
+    .addStringOption((option) =>
+      option.setName('reason').setDescription('The reason').setRequired(true)
+    )
+    .addIntegerOption((option) =>
+      option
+        .setName('days')
+        .setDescription(
+          'Number of days of messages to delete (between 0 and 7)'
+        )
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    const targetUser = await interaction.options.getUser('target');
+
+    if (await isServerStaff(interaction, targetUser)) {
+      return await sendNoTargetStaffReply(interaction);
+    }
+
+    const guildBans = await interaction.guild.bans.fetch();
+    if (guildBans.has(targetUser.id)) {
+      return await interaction.reply('The user is already banned');
+    }
+
+    const reason = interaction.options.getString('reason');
+    if (!verifyReasonLength(reason, interaction)) return;
+
+    const days = interaction.options.getInteger('days');
+    if (days < 0 || days > 7) {
+      return await interaction.reply(
+        'The number of days are not between 0 and 7'
+      );
+    }
+
+    const banText = banIntro + reason + unbanRequest;
+
+    try {
+      await dmUser(interaction, targetUser, banText);
+      await interaction.guild.bans.create(targetUser, {days, reason});
+      await interaction.channel.send(
+        `${targetUser} was banned. Days of user messages deleted: ${days}`
+      );
+      await recordBanInDB(interaction, targetUser, reason);
+      await sendToAuditLogsChannel(interaction, {
+        color: '#0099ff',
+        titleMsg: `${targetUser.tag} was banned by ${interaction.user.tag}:`,
+        description: reason,
+        targetUser: targetUser,
+      });
+      await interaction.reply(`Ban command was successful`);
+    } catch (err) {
+      console.error(err);
+      return await interaction.reply(
+        `There was an error while executing the command`
+      );
+    }
+  },
+};
+
+async function dmUser(interaction, targetUser, banText) {
+  try {
+    await targetUser.send(banText);
+    await interaction.channel.send(
+      `Message regarding ban was sent to ${targetUser} successfully`
+    );
+  } catch (err) {
+    if (err.code === Discord.Constants.APIErrors.CANNOT_MESSAGE_USER) {
+      interaction.channel.send('The user cannot be messaged.');
+    } else {
+      throw new Error(err.message);
+    }
+  }
+}
+
+async function recordBanInDB(interaction, targetUser, reason) {
+  const banSQL = `INSERT INTO infractions (timestamp, user, action, length_of_time, reason, valid, moderator) VALUES 
+  (now(), ?, 'ban', NULL, ?, true, ?)`;
+  const banValues = [targetUser.id, reason, interaction.user.id];
+
+  const modlogSQL = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) VALUES (now(), ?, ?, NULL, ?)`;
+  const modlogValues = [interaction.user.id, `Ban: ${targetUser.id}`, reason];
+
+  try {
+    await promisePool.execute(banSQL, banValues);
+    await promisePool.execute(modlogSQL, modlogValues);
+  } catch (err) {
+    await interaction.channel.send('There was an error when writing to the DB');
+    console.error(err);
+  }
+}

--- a/slash-commands/moderation/ban.js
+++ b/slash-commands/moderation/ban.js
@@ -25,11 +25,19 @@ module.exports = {
     )
     .addIntegerOption((option) =>
       option
-        .setName('days')
+        .setName('delete_msg_days')
         .setDescription(
-          'Number of days of messages to delete (between 0 and 7, inclusive)'
+          'Number of days of messages to delete (between 0 and 7)'
         )
         .setRequired(true)
+        .addChoice('0 days', 0)
+        .addChoice('1 day', 1)
+        .addChoice('2 days', 2)
+        .addChoice('3 days', 3)
+        .addChoice('4 days', 4)
+        .addChoice('5 days', 5)
+        .addChoice('6 days', 6)
+        .addChoice('7 days', 7)
     ),
   async execute(interaction) {
     const targetUser = await interaction.options.getUser('target');
@@ -46,12 +54,7 @@ module.exports = {
     const reason = interaction.options.getString('reason');
     if (!verifyReasonLength(reason, interaction)) return;
 
-    const days = interaction.options.getInteger('days');
-    if (days < 0 || days > 7) {
-      return await interaction.reply(
-        'The number of days are not between 0 and 7, inclusive'
-      );
-    }
+    const days = interaction.options.getInteger('delete_msg_days');
 
     const banText = banIntro + reason + unbanRequest;
 

--- a/slash-commands/moderation/ban.js
+++ b/slash-commands/moderation/ban.js
@@ -27,7 +27,7 @@ module.exports = {
       option
         .setName('days')
         .setDescription(
-          'Number of days of messages to delete (between 0 and 7)'
+          'Number of days of messages to delete (between 0 and 7, inclusive)'
         )
         .setRequired(true)
     ),
@@ -49,7 +49,7 @@ module.exports = {
     const days = interaction.options.getInteger('days');
     if (days < 0 || days > 7) {
       return await interaction.reply(
-        'The number of days are not between 0 and 7'
+        'The number of days are not between 0 and 7, inclusive'
       );
     }
 

--- a/slash-commands/moderation/unban.js
+++ b/slash-commands/moderation/unban.js
@@ -1,0 +1,60 @@
+const {SlashCommandBuilder} = require('@discordjs/builders');
+const {promisePool} = require('../../config/db');
+const {sendToAuditLogsChannel} = require('../../helpers/sendToAuditLogs');
+const {
+  isServerStaff,
+  sendNoTargetStaffReply,
+} = require('../../helpers/validation');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('unban')
+    .setDefaultPermission(false)
+    .setDescription('Unbans a user')
+    .addUserOption((option) =>
+      option.setName('target').setDescription('The user').setRequired(true)
+    ),
+
+  async execute(interaction) {
+    const targetUser = interaction.options.getUser('target');
+
+    if (await isServerStaff(interaction, targetUser)) {
+      return await sendNoTargetStaffReply(interaction);
+    }
+
+    const guildBans = await interaction.guild.bans.fetch();
+    if (!guildBans.has(targetUser.id)) {
+      return await interaction.reply('The user is not banned');
+    }
+
+    try {
+      await interaction.guild.bans.remove(targetUser);
+      await interaction.channel.send(`${targetUser} was unbanned`);
+      await recordUnbanInDB(interaction, targetUser);
+      await sendToAuditLogsChannel(interaction, {
+        color: '#0099ff',
+        titleMsg: `${targetUser.tag} was unbanned by ${interaction.user.tag}:`,
+        targetUser: targetUser,
+      });
+      await interaction.reply(`Unban command was successful`);
+    } catch (err) {
+      console.error(err);
+      return await interaction.reply(
+        `There was an error while executing the command`
+      );
+    }
+  },
+};
+
+async function recordUnbanInDB(interaction, targetUser) {
+  const modlogSQL = `INSERT INTO mod_log (timestamp, moderator, action, length_of_time, reason) VALUES
+  (now(), ?, ?, NULL, NULL)`;
+  const modlogValues = [interaction.user.id, `Unban: ${targetUser.id}`];
+
+  try {
+    await promisePool.execute(modlogSQL, modlogValues);
+  } catch (err) {
+    await interaction.channel.send('There was an error when writing to the DB');
+    console.error(err);
+  }
+}

--- a/slash-commands/moderation/unban.js
+++ b/slash-commands/moderation/unban.js
@@ -32,7 +32,7 @@ module.exports = {
     }
 
     const reason = await interaction.options.getString('reason');
-    if (!verifyReasonLength(reason, interaction)) return;
+    if (reason && !verifyReasonLength(reason, interaction)) return;
 
     try {
       await interaction.guild.bans.remove(targetUser);


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #296 

### Description
<!-- Brief description of change -->
Adds ban and unban slash commands. Ban now works for a user that has DMs disabled or is not part of the guild as long as the user-id is entered. The ban command also includes an option for 0 to 7 days of messages to delete when banning a user. This range was chosen because it's what the discord.js API supports.

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->
I added the command permissions to the commandRoles permission handler for consistency even though now with Discord permissions v2 that functionality of setting command permissions does not work.

## Any helpful knowledge/context for the reviewer?
Since our programmatic permission setting is currently not working you may need to go to Server Settings -> Interactions -> Your Dev Bot and enable the command manually for the Moderator role and above.

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test?
Test with both your admin and alt account.

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
