### PR TITLE
check slash cmd role perms in interaction handler

### DIFF
--- a/config/slashCommandPermissions.js
+++ b/config/slashCommandPermissions.js
@@ -16,8 +16,6 @@ const commandRoles = new Map([
   ['ping', allStaffRoles],
   ['notes', allStaffRoles],
   ['addnote', allStaffRoles],
-  ['notes', allStaffRoles],
-  ['ping', allStaffRoles],
   ['ban', moderatorRoles],
   ['clearmessages', moderatorRoles],
   ['kick', moderatorRoles],

--- a/config/slashCommandPermissions.js
+++ b/config/slashCommandPermissions.js
@@ -1,7 +1,5 @@
 const {ID_CODE_COUNSELOR, ID_MODERATOR, ID_ADMIN, ID_SUPER_ADMIN} = process.env;
 
-// Commands with .setDefaultPermission(false) need to be enabled by adding role IDs to array.
-
 const allStaffRoles = [
   ID_CODE_COUNSELOR,
   ID_MODERATOR,
@@ -10,7 +8,11 @@ const allStaffRoles = [
 ];
 const moderatorRoles = [ID_MODERATOR, ID_ADMIN, ID_SUPER_ADMIN];
 
+const everyoneRoles = ['@everyone'];
+
 const commandRoles = new Map([
+  ['helpcenter', everyoneRoles],
+  ['stats', everyoneRoles],
   ['ping', allStaffRoles],
   ['notes', allStaffRoles],
   ['addnote', allStaffRoles],
@@ -22,29 +24,6 @@ const commandRoles = new Map([
   ['removetimeout', moderatorRoles],
 ]);
 
-/**
- * Returns an array used to set all application command permissions
- * @param {any} commands - Discord.js Collection of application commands
- * @return {Object[]} Discord.js array of objects to set permissions for all commands
- */
-function getDiscordJsFullPermissions(commands) {
-  return commands.map((command) => {
-    return commandRoles.has(command.name)
-      ? {
-          id: command.id,
-          permissions: commandRoles.get(command.name).map((roleId) => ({
-            id: roleId,
-            type: 'ROLE',
-            permission: true,
-          })),
-        }
-      : {
-          id: command.id,
-          permissions: [],
-        };
-  });
-}
-
 module.exports = {
-  getDiscordJsFullPermissions,
+  commandRoles,
 };

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1,7 +1,27 @@
+const {commandRoles} = require('../config/slashCommandPermissions');
+
+function isAuthorized(interaction, commandRoles) {
+  const allowedRoles = commandRoles.get(interaction.commandName);
+  if (
+    allowedRoles[0] === '@everyone' ||
+    interaction.member.roles.cache.some((r) => allowedRoles.includes(r.id))
+  ) {
+    return true;
+  }
+  return false;
+}
+
 module.exports = {
   name: 'interactionCreate',
   async execute(interaction) {
     if (!interaction.isCommand()) return;
+
+    if (!isAuthorized(interaction, commandRoles)) {
+      return await interaction.reply({
+        content: `You don't have permissions for this command`,
+        ephemeral: true,
+      });
+    }
 
     const command = interaction.client.slashCommands.get(
       interaction.commandName

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -2,13 +2,10 @@ const {commandRoles} = require('../config/slashCommandPermissions');
 
 function isAuthorized(interaction, commandRoles) {
   const allowedRoles = commandRoles.get(interaction.commandName);
-  if (
+  return (
     allowedRoles[0] === '@everyone' ||
     interaction.member.roles.cache.some((r) => allowedRoles.includes(r.id))
-  ) {
-    return true;
-  }
-  return false;
+  );
 }
 
 module.exports = {
@@ -18,7 +15,7 @@ module.exports = {
 
     if (!isAuthorized(interaction, commandRoles)) {
       return await interaction.reply({
-        content: `You don't have permissions for this command`,
+        content: `You don't have permission to use this command.`,
         ephemeral: true,
       });
     }

--- a/events/ready.js
+++ b/events/ready.js
@@ -1,31 +1,7 @@
-const {
-  getDiscordJsFullPermissions,
-} = require('../config/slashCommandPermissions');
-
 module.exports = {
   name: 'ready',
   once: true,
   async execute(client) {
-    console.log(
-      `Ready! Logged in as ${client.user.tag}. Updating permissions.`
-    );
-
-    try {
-      const commands = await client.guilds.cache
-        .get(process.env.GUILD_ID)
-        ?.commands.fetch();
-
-      const fullPermissions = getDiscordJsFullPermissions(commands);
-
-      // Set role permissions by bulk method.
-      // Docs: https://discordjs.guide/interactions/slash-commands.html#bulk-update-permissions
-
-      await client.guilds.cache
-        .get(process.env.GUILD_ID)
-        ?.commands.permissions.set({fullPermissions});
-      console.log('Permissions for slash-commands updated.');
-    } catch (err) {
-      console.error(err);
-    }
+    console.log(`Ready! Logged in as ${client.user.tag}.`);
   },
 };

--- a/slash-commands/moderation/addnote.js
+++ b/slash-commands/moderation/addnote.js
@@ -10,7 +10,6 @@ const {
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('addnote')
-    .setDefaultPermission(false)
     .setDescription('Write a user note and store in the db')
     .addUserOption((option) =>
       option.setName('target').setDescription('The user').setRequired(true)

--- a/slash-commands/moderation/clearmessages.js
+++ b/slash-commands/moderation/clearmessages.js
@@ -5,7 +5,6 @@ const {sendToAuditLogsChannel} = require('../../helpers/sendToAuditLogs');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('clearmessages')
-    .setDefaultPermission(false)
     .setDescription('Clears a certain number of messages')
     .addIntegerOption((option) =>
       option

--- a/slash-commands/moderation/kick.js
+++ b/slash-commands/moderation/kick.js
@@ -15,7 +15,6 @@ const kickOutro = ' ```';
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('kick')
-    .setDefaultPermission(false)
     .setDescription('Kick a user')
     .addUserOption((option) =>
       option.setName('target').setDescription('The user').setRequired(true)

--- a/slash-commands/moderation/notes.js
+++ b/slash-commands/moderation/notes.js
@@ -7,7 +7,6 @@ const {promisePool} = require('../../config/db');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('notes')
-    .setDefaultPermission(false)
     .setDescription('Finds user notes record in db and returns it to channel')
     .addUserOption((option) =>
       option.setName('target').setDescription('The user').setRequired(true)

--- a/slash-commands/moderation/removenote.js
+++ b/slash-commands/moderation/removenote.js
@@ -5,7 +5,6 @@ const {promisePool} = require('../../config/db');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('removenote')
-    .setDefaultPermission(false)
     .setDescription('Removes a specific note based on the note ID provided')
     .addUserOption((option) =>
       option.setName('user').setDescription('The user').setRequired(true)

--- a/slash-commands/moderation/removetimeout.js
+++ b/slash-commands/moderation/removetimeout.js
@@ -6,7 +6,6 @@ const {promisePool} = require('../../config/db');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('removetimeout')
-    .setDefaultPermission(false)
     .setDescription('Remove timeout from a user')
     .addUserOption((option) =>
       option

--- a/slash-commands/moderation/timeout.js
+++ b/slash-commands/moderation/timeout.js
@@ -8,7 +8,6 @@ const {promisePool} = require('../../config/db');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('timeout')
-    .setDefaultPermission(false)
     .setDescription('Timeout a user')
     .addUserOption((option) =>
       option

--- a/slash-commands/moderation/verbal.js
+++ b/slash-commands/moderation/verbal.js
@@ -11,7 +11,6 @@ const {verifyReasonLength} = require('../../helpers/stringHelpers');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('verbal')
-    .setDefaultPermission(false)
     .setDescription('Sends a user a verbal warning and logs note in db')
     .addUserOption((option) =>
       option.setName('target').setDescription('The user').setRequired(true)

--- a/slash-commands/utility/ping.js
+++ b/slash-commands/utility/ping.js
@@ -3,7 +3,6 @@ const {SlashCommandBuilder} = require('@discordjs/builders');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('ping')
-    .setDefaultPermission(false)
     .setDescription('Replies with Pong!'),
   async execute(interaction) {
     const sent = await interaction.reply({


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #321

### Description
<!-- Brief description of change -->
Removes slash command permission setting by bulk update method as it's no longer supported by Discord in permissions v2. Moves role permission checks into a handler which checks permissions on interactionCreate event. Removes the default permissions false setting for the slash commands. Guild members will be able to launch all slash commands but a reply error message is presented for commands where the user does not have permission (similar to current text commands).

<!-- Add any additional expected behavior here if it is not described in the linked issue. -->

## Any helpful knowledge/context for the reviewer?

- Is a re-seeding of the database necessary? No
- Any new dependencies to install? No
- Any special requirements to test?
Redeploy the commands with deployCommands.js.
Check Discord Server Settings - Interactions - "Your test bot" to see the current "Discord" permissions for your slash commands. Confirm that your bot slash commands are availabe to @everyone and All channels and are Synced. It's possible you may need to adjust the settings since they were previously limited to some roles. Basically, all users should have access to all slash commands in the Discord settings (since we handle the permissions with the bot).

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
