### PR TITLE
Remove submit a request from plaintext

### DIFF
--- a/slash-commands/utility/helpcenter.js
+++ b/slash-commands/utility/helpcenter.js
@@ -17,7 +17,6 @@ module.exports = {
       await interaction.reply({
         content:
           '**Codecademy Help Center:** https://help.codecademy.com/hc/en-us\n' +
-          '**Submit A Request:** https://help.codecademy.com/hc/en-us/requests/new\n' +
           '**Bug Reporting:** To report a bug, click *Get Unstuck* in the learning environment, then click *Bugs*.\n' +
           'All billing-related queries should be directed to the Submit A Request form linked above.',
       });


### PR DESCRIPTION
### Description
<!-- Brief description of change -->
Removes "Submit a Request" field from the plaintext version of the helpcenter slash command.

### Please make sure you've attempted to meet the following coding standards
- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
