### PR TITLE
remove setDefaultPermission from ban/unban

### DIFF
--- a/slash-commands/moderation/ban.js
+++ b/slash-commands/moderation/ban.js
@@ -15,7 +15,6 @@ const unbanRequest =
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('ban')
-    .setDefaultPermission(false)
     .setDescription('Bans a user')
     .addUserOption((option) =>
       option.setName('target').setDescription('The user').setRequired(true)

--- a/slash-commands/moderation/unban.js
+++ b/slash-commands/moderation/unban.js
@@ -10,7 +10,6 @@ const {verifyReasonLength} = require('../../helpers/stringHelpers');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('unban')
-    .setDefaultPermission(false)
     .setDescription('Unbans a user')
     .addUserOption((option) =>
       option.setName('target').setDescription('The user').setRequired(true)


### PR DESCRIPTION
## What issue is this solving?
<!-- replace ??? with the issue number. This will ensure the related issue is automatically closed when the PR is merged. -->
Closes #334 

### Description
<!-- Brief description of change -->
These 2 commands (ban and unban) still had setDefaultPermission false from when the slash commands had an older implementation of the Discord permission system and the permissions were configured on deployment. With the current permission check at the command level this is not needed anymore. This line had already been removed from all other commands.

### Please make sure you've attempted to meet the following coding standards
- [X] Code has been tested and does not produce errors
- [X] Code is readable and formatted
- [X] There isn't any unnecessary commented-out code
